### PR TITLE
Added resin viscosity and cure wavelength properties to resins

### DIFF
--- a/data/materials/altana/altana-cubic-ink-high-performance-4-4800-vp.yaml
+++ b/data/materials/altana/altana-cubic-ink-high-performance-4-4800-vp.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#595959ff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 1436
+  viscosity_25c: 788
+  viscosity_40c: 278
+  viscosity_60c: 103

--- a/data/materials/altana/altana-cubic-ink-mold-2200-vp.yaml
+++ b/data/materials/altana/altana-cubic-ink-mold-2200-vp.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#fffc6aff'
 properties:
   density: 1.118
+  cure_wavelength: 405
+  viscosity_18c: 68
+  viscosity_25c: 45
+  viscosity_40c: 23
+  viscosity_60c: 13

--- a/data/materials/altana/altana-cubic-ink-tough-2100-vp-black.yaml
+++ b/data/materials/altana/altana-cubic-ink-tough-2100-vp-black.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#595959ff'
 properties:
   density: 1.1
+  cure_wavelength: 405
+  viscosity_18c: 291
+  viscosity_25c: 173
+  viscosity_40c: 70
+  viscosity_60c: 30

--- a/data/materials/forward-am/forward-am-ultracur3d-rg-3280.yaml
+++ b/data/materials/forward-am/forward-am-ultracur3d-rg-3280.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#d6d7d8ff'
 properties:
   density: 1.65
+  cure_wavelength: 405
+  viscosity_18c: 531
+  viscosity_25c: 362
+  viscosity_40c: 336
+  viscosity_60c: 87

--- a/data/materials/forward-am/forward-am-ultracur3d-rg-35-b.yaml
+++ b/data/materials/forward-am/forward-am-ultracur3d-rg-35-b.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#595959ff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 530
+  viscosity_25c: 312
+  viscosity_40c: 127
+  viscosity_60c: 51

--- a/data/materials/forward-am/forward-am-ultracur3d-rg-35.yaml
+++ b/data/materials/forward-am/forward-am-ultracur3d-rg-35.yaml
@@ -12,3 +12,8 @@ tags:
 - transparent
 properties:
   density: 1.12
+  cure_wavelength: 405
+  viscosity_18c: 1798
+  viscosity_25c: 925
+  viscosity_40c: 279
+  viscosity_60c: 87

--- a/data/materials/forward-am/forward-am-ultracur3d-st-45-m.yaml
+++ b/data/materials/forward-am/forward-am-ultracur3d-st-45-m.yaml
@@ -12,3 +12,8 @@ tags:
 - translucent
 properties:
   density: 1.12
+  cure_wavelength: 405
+  viscosity_18c: 530
+  viscosity_25c: 312
+  viscosity_40c: 127
+  viscosity_60c: 51

--- a/data/materials/forward-am/forward-am-ultracur3d-st-45.yaml
+++ b/data/materials/forward-am/forward-am-ultracur3d-st-45.yaml
@@ -12,3 +12,8 @@ tags:
 - translucent
 properties:
   density: 1.12
+  cure_wavelength: 405
+  viscosity_18c: 530
+  viscosity_25c: 312
+  viscosity_40c: 127
+  viscosity_60c: 51

--- a/data/materials/forward-am/forward-am-ultracur3d-st-7500-g.yaml
+++ b/data/materials/forward-am/forward-am-ultracur3d-st-7500-g.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#9c9d9dff'
 properties:
   density: 1.1
+  cure_wavelength: 405
+  viscosity_18c: 279
+  viscosity_25c: 170
+  viscosity_40c: 72
+  viscosity_60c: 31

--- a/data/materials/henkel/henkel-loctite-3d-3843.yaml
+++ b/data/materials/henkel/henkel-loctite-3d-3843.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#595959ff'
 properties:
   density: 1.07
+  cure_wavelength: 405
+  viscosity_18c: 863
+  viscosity_25c: 510
+  viscosity_40c: 204
+  viscosity_60c: 81

--- a/data/materials/henkel/henkel-loctite-3d-ind147.yaml
+++ b/data/materials/henkel/henkel-loctite-3d-ind147.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#595959ff'
 properties:
   density: 1.07
+  cure_wavelength: 405
+  viscosity_18c: 3845
+  viscosity_25c: 1634
+  viscosity_40c: 350
+  viscosity_60c: 80

--- a/data/materials/henkel/henkel-loctite-3d-ind249.yaml
+++ b/data/materials/henkel/henkel-loctite-3d-ind249.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#595959ff'
 properties:
   density: 1.1
+  cure_wavelength: 405
+  viscosity_18c: 836
+  viscosity_25c: 405
+  viscosity_40c: 120
+  viscosity_60c: 36

--- a/data/materials/henkel/henkel-loctite-3d-ind3380.yaml
+++ b/data/materials/henkel/henkel-loctite-3d-ind3380.yaml
@@ -12,3 +12,8 @@ tags:
 - esd_safe
 properties:
   density: 1.1
+  cure_wavelength: 405
+  viscosity_18c: 6212
+  viscosity_25c: 3074
+  viscosity_40c: 950
+  viscosity_60c: 243

--- a/data/materials/henkel/henkel-loctite-3d-ind402.yaml
+++ b/data/materials/henkel/henkel-loctite-3d-ind402.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#595959ff'
 properties:
   density: 1.05
+  cure_wavelength: 405
+  viscosity_18c: 21000
+  viscosity_25c: 12000
+  viscosity_40c: 5200
+  viscosity_60c: 1204

--- a/data/materials/henkel/henkel-loctite-3d-ind475.yaml
+++ b/data/materials/henkel/henkel-loctite-3d-ind475.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#d6d7d8ff'
 properties:
   density: 1.0
+  cure_wavelength: 405
+  viscosity_18c: 1784
+  viscosity_25c: 1223
+  viscosity_40c: 580
+  viscosity_60c: 276

--- a/data/materials/henkel/henkel-loctite-3d-ind5714.yaml
+++ b/data/materials/henkel/henkel-loctite-3d-ind5714.yaml
@@ -12,3 +12,8 @@ tags:
 - biocompatible
 properties:
   density: 1.01
+  cure_wavelength: 405
+  viscosity_18c: 3205
+  viscosity_25c: 2091
+  viscosity_40c: 1018
+  viscosity_60c: 467

--- a/data/materials/henkel/henkel-loctite-3d-ind6845.yaml
+++ b/data/materials/henkel/henkel-loctite-3d-ind6845.yaml
@@ -9,3 +9,8 @@ primary_color:
   color_rgba: '#595959ff'
 properties:
   density: 1.07
+  cure_wavelength: 405
+  viscosity_18c: 1042
+  viscosity_25c: 609
+  viscosity_40c: 233
+  viscosity_60c: 89

--- a/data/materials/henkel/henkel-loctite-3d-med3394-bk.yaml
+++ b/data/materials/henkel/henkel-loctite-3d-med3394-bk.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#595959ff'
 properties:
   density: 1.09
+  cure_wavelength: 405
+  viscosity_18c: 1607
+  viscosity_25c: 881
+  viscosity_40c: 299
+  viscosity_60c: 101

--- a/data/materials/henkel/henkel-loctite-3d-med3394-wh.yaml
+++ b/data/materials/henkel/henkel-loctite-3d-med3394-wh.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#d6d7d8ff'
 properties:
   density: 1.09
+  cure_wavelength: 405
+  viscosity_18c: 1607
+  viscosity_25c: 881
+  viscosity_40c: 299
+  viscosity_60c: 101

--- a/data/materials/henkel/henkel-loctite-3d-pro476.yaml
+++ b/data/materials/henkel/henkel-loctite-3d-pro476.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#595959ff'
 properties:
   density: 1.08
+  cure_wavelength: 405
+  viscosity_18c: 1112
+  viscosity_25c: 657
+  viscosity_40c: 259
+  viscosity_60c: 101

--- a/data/materials/liqcreate/liqcreate-bio-med-clear.yaml
+++ b/data/materials/liqcreate/liqcreate-bio-med-clear.yaml
@@ -12,3 +12,8 @@ tags:
 - biocompatible
 properties:
   density: 1.18
+  cure_wavelength: 405
+  viscosity_18c: 791
+  viscosity_25c: 373
+  viscosity_40c: 114
+  viscosity_60c: 37

--- a/data/materials/liqcreate/liqcreate-bio-med.yaml
+++ b/data/materials/liqcreate/liqcreate-bio-med.yaml
@@ -12,3 +12,8 @@ tags:
 - biocompatible
 properties:
   density: 1.18
+  cure_wavelength: 405
+  viscosity_18c: 791
+  viscosity_25c: 373
+  viscosity_40c: 114
+  viscosity_60c: 37

--- a/data/materials/liqcreate/liqcreate-clear-impact.yaml
+++ b/data/materials/liqcreate/liqcreate-clear-impact.yaml
@@ -12,3 +12,8 @@ tags:
 - translucent
 properties:
   density: 1.12
+  cure_wavelength: 405
+  viscosity_18c: 1822
+  viscosity_25c: 912
+  viscosity_40c: 269
+  viscosity_60c: 83

--- a/data/materials/liqcreate/liqcreate-composite-x.yaml
+++ b/data/materials/liqcreate/liqcreate-composite-x.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#d6d7d8ff'
 properties:
   density: 1.52
+  cure_wavelength: 405
+  viscosity_18c: 313
+  viscosity_25c: 196
+  viscosity_40c: 86
+  viscosity_60c: 39

--- a/data/materials/liqcreate/liqcreate-esd.yaml
+++ b/data/materials/liqcreate/liqcreate-esd.yaml
@@ -12,3 +12,8 @@ tags:
 - esd_safe
 properties:
   density: 1.18
+  cure_wavelength: 405
+  viscosity_18c: 1174
+  viscosity_25c: 698
+  viscosity_40c: 263
+  viscosity_60c: 116

--- a/data/materials/liqcreate/liqcreate-flame-retardant-hdt.yaml
+++ b/data/materials/liqcreate/liqcreate-flame-retardant-hdt.yaml
@@ -12,3 +12,8 @@ tags:
 - self_extinguishing
 properties:
   density: 1.12
+  cure_wavelength: 405
+  viscosity_18c: 1389
+  viscosity_25c: 630
+  viscosity_40c: 165
+  viscosity_60c: 49

--- a/data/materials/liqcreate/liqcreate-premium-black.yaml
+++ b/data/materials/liqcreate/liqcreate-premium-black.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#595959ff'
 properties:
   density: 1.18
+  cure_wavelength: 405
+  viscosity_18c: 956
+  viscosity_25c: 464
+  viscosity_40c: 140
+  viscosity_60c: 46

--- a/data/materials/liqcreate/liqcreate-premium-white.yaml
+++ b/data/materials/liqcreate/liqcreate-premium-white.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#d6d7d8ff'
 properties:
   density: 1.18
+  cure_wavelength: 405
+  viscosity_18c: 898
+  viscosity_25c: 406
+  viscosity_40c: 128
+  viscosity_60c: 42

--- a/data/materials/liqcreate/liqcreate-rigid-pro.yaml
+++ b/data/materials/liqcreate/liqcreate-rigid-pro.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#595959ff'
 properties:
   density: 1.12
+  cure_wavelength: 405
+  viscosity_18c: 556
+  viscosity_25c: 285
+  viscosity_40c: 92
+  viscosity_60c: 1

--- a/data/materials/liqcreate/liqcreate-strong-x.yaml
+++ b/data/materials/liqcreate/liqcreate-strong-x.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#c8c8c8ff'
 properties:
   density: 1.12
+  cure_wavelength: 405
+  viscosity_18c: 538
+  viscosity_25c: 278
+  viscosity_40c: 92
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-basic-black.yaml
+++ b/data/materials/prusament-resin/prusament-resin-basic-black.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#000000ff'
 properties:
   density: 1.03
+  cure_wavelength: 405
+  viscosity_18c: 360
+  viscosity_25c: 207
+  viscosity_40c: 81
+  viscosity_60c: 32

--- a/data/materials/prusament-resin/prusament-resin-basic-grey.yaml
+++ b/data/materials/prusament-resin/prusament-resin-basic-grey.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#bac4c4ff'
 properties:
   density: 1.03
+  cure_wavelength: 405
+  viscosity_18c: 360
+  viscosity_25c: 207
+  viscosity_40c: 81
+  viscosity_60c: 32

--- a/data/materials/prusament-resin/prusament-resin-basic-orange.yaml
+++ b/data/materials/prusament-resin/prusament-resin-basic-orange.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#ff8040ff'
 properties:
   density: 1.03
+  cure_wavelength: 405
+  viscosity_18c: 360
+  viscosity_25c: 207
+  viscosity_40c: 81
+  viscosity_60c: 32

--- a/data/materials/prusament-resin/prusament-resin-flex80-black.yaml
+++ b/data/materials/prusament-resin/prusament-resin-flex80-black.yaml
@@ -11,3 +11,8 @@ primary_color:
 properties:
   density: 1.0
   hardness_shore_a: 80
+  cure_wavelength: 405
+  viscosity_18c: 255
+  viscosity_25c: 148
+  viscosity_40c: 58
+  viscosity_60c: 26

--- a/data/materials/prusament-resin/prusament-resin-flex80-transparent-clear.yaml
+++ b/data/materials/prusament-resin/prusament-resin-flex80-transparent-clear.yaml
@@ -13,3 +13,8 @@ tags:
 properties:
   density: 1.0
   hardness_shore_a: 80
+  cure_wavelength: 405
+  viscosity_18c: 255
+  viscosity_25c: 148
+  viscosity_40c: 58
+  viscosity_60c: 26

--- a/data/materials/prusament-resin/prusament-resin-flex80-white.yaml
+++ b/data/materials/prusament-resin/prusament-resin-flex80-white.yaml
@@ -11,3 +11,8 @@ primary_color:
 properties:
   density: 1.0
   hardness_shore_a: 80
+  cure_wavelength: 405
+  viscosity_18c: 255
+  viscosity_25c: 148
+  viscosity_40c: 58
+  viscosity_60c: 26

--- a/data/materials/prusament-resin/prusament-resin-impact65-black.yaml
+++ b/data/materials/prusament-resin/prusament-resin-impact65-black.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#595959ff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 404
+  viscosity_25c: 234
+  viscosity_40c: 91
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-alabaster-white.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-alabaster-white.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#d6d7d8ff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-anthracite-grey.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-anthracite-grey.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#808080ff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-brick-red.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-brick-red.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#b46056ff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 68
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-bright-cyan.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-bright-cyan.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#0079a7ff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-bright-magenta.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-bright-magenta.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#ff0066ff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-bright-yellow.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-bright-yellow.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#c7b91fff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-classic-red.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-classic-red.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#ec0000ff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-grass-green.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-grass-green.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#37823fff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-neutral-beige.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-neutral-beige.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#bf9c87ff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-prusa-orange.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-prusa-orange.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#ff8040ff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-prusa-pro-green.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-prusa-pro-green.yaml
@@ -7,3 +7,8 @@ class: SLA
 abbreviation: ''
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-rich-black.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-rich-black.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#595959ff'
 properties:
   density: 1.0
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-sandstone.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-sandstone.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#eea061ff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 2

--- a/data/materials/prusament-resin/prusament-resin-model-solid-grey.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-solid-grey.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#9c9d9dff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-terra-brown.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-terra-brown.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#7a5c45ff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-transparent-amber.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-transparent-amber.yaml
@@ -12,3 +12,8 @@ tags:
 - transparent
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-transparent-clear.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-transparent-clear.yaml
@@ -12,3 +12,8 @@ tags:
 - transparent
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-transparent-green.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-transparent-green.yaml
@@ -12,3 +12,8 @@ tags:
 - transparent
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-transparent-red.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-transparent-red.yaml
@@ -12,3 +12,8 @@ tags:
 - transparent
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1

--- a/data/materials/prusament-resin/prusament-resin-model-ultra-violet.yaml
+++ b/data/materials/prusament-resin/prusament-resin-model-ultra-violet.yaml
@@ -10,3 +10,8 @@ primary_color:
   color_rgba: '#413a7aff'
 properties:
   density: 1.11
+  cure_wavelength: 405
+  viscosity_18c: 287
+  viscosity_25c: 167
+  viscosity_40c: 66
+  viscosity_60c: 1


### PR DESCRIPTION
Exported viscosity_18c, viscosity_25c, viscosity_40c, viscosity_60c, cure_wavelength, and hardness_shore_a from Directus for 57 SLA materials across brands:
- Prusament Resin
- Henkel
- Forward AM
- Liqcreate
- Altana.