### PR TITLE
Update inconsistent Prusament URLs

### DIFF
--- a/data/materials/prusament/prusament-petg-prusa-pro-green.yaml
+++ b/data/materials/prusament/prusament-petg-prusa-pro-green.yaml
@@ -6,7 +6,7 @@ name: PETG Prusa Pro Green
 class: FFF
 type: PETG
 abbreviation: PETG
-url: https://www.prusa3d.com/cs/produkt/prusament-petg-prusa-pro-green-1kg/
+url: https://www.prusa3d.com/product/prusament-petg-prusa-pro-green-1kg/
 primary_color:
   color_rgba: '#00fa9aff'
 properties:

--- a/data/materials/prusament/prusament-pla-chalky-blue.yaml
+++ b/data/materials/prusament/prusament-pla-chalky-blue.yaml
@@ -6,7 +6,7 @@ name: PLA Chalky Blue
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.prusa3d.com/en/product/prusament-pla-chalky-blue-1kg/
+url: https://www.prusa3d.com/product/prusament-pla-chalky-blue-1kg/
 primary_color:
   color_rgba: '#6f9aaaff'
 tags:


### PR DESCRIPTION
All other Prusament URLs points to the canonical URL, so these should as well.