### PR TITLE
Add missing product URLs to Prusament filaments

### DIFF
--- a/data/material-packages/prusament/prusament-asa-jet-black-800-spool.yaml
+++ b/data/material-packages/prusament/prusament-asa-jet-black-800-spool.yaml
@@ -1,6 +1,7 @@
 uuid: e84b5751-25ab-5d97-8d82-591644bc93f9
 slug: prusament-asa-jet-black-800-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-asa-jet-black-800g-nfc/
 material:
   slug: prusament-asa-jet-black
 nominal_netto_full_weight: 800

--- a/data/material-packages/prusament/prusament-asa-lipstick-red-800-spool.yaml
+++ b/data/material-packages/prusament/prusament-asa-lipstick-red-800-spool.yaml
@@ -1,6 +1,7 @@
 uuid: b5a6daf0-acfe-51f5-a4f7-63ddb9f47766
 slug: prusament-asa-lipstick-red-800-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-asa-lipstick-red-800g-nfc/
 material:
   slug: prusament-asa-lipstick-red
 nominal_netto_full_weight: 800

--- a/data/material-packages/prusament/prusament-asa-natural-800-spool.yaml
+++ b/data/material-packages/prusament/prusament-asa-natural-800-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 874c282c-8650-5209-9f67-93f6eb77b2a7
 slug: prusament-asa-natural-800-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-asa-natural-800g-nfc/
 material:
   slug: prusament-asa-natural
 nominal_netto_full_weight: 800

--- a/data/material-packages/prusament/prusament-asa-olive-green-800-spool.yaml
+++ b/data/material-packages/prusament/prusament-asa-olive-green-800-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 28c518e7-7292-5f89-be1b-f8b0ee3bca0a
 slug: prusament-asa-olive-green-800-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-asa-olive-green-800g-nfc/
 gtin: 8594173676305
 container:
   slug: prusament-spool-1kg

--- a/data/material-packages/prusament/prusament-asa-prusa-galaxy-black-800-spool.yaml
+++ b/data/material-packages/prusament/prusament-asa-prusa-galaxy-black-800-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 0f378be9-ea89-5795-a898-099bb896e7c3
 slug: prusament-asa-prusa-galaxy-black-800-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-asa-prusa-galaxy-black-800g-nfc/
 material:
   slug: prusament-asa-prusa-galaxy-black
 nominal_netto_full_weight: 800

--- a/data/material-packages/prusament/prusament-asa-prusa-orange-800-spool.yaml
+++ b/data/material-packages/prusament/prusament-asa-prusa-orange-800-spool.yaml
@@ -1,6 +1,7 @@
 uuid: dc1f51f3-fa60-5c5c-8012-55a5e7d83673
 slug: prusament-asa-prusa-orange-800-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-asa-prusa-orange-800g-nfc/
 material:
   slug: prusament-asa-prusa-orange
 nominal_netto_full_weight: 800

--- a/data/material-packages/prusament/prusament-asa-prusa-pro-green-800-spool.yaml
+++ b/data/material-packages/prusament/prusament-asa-prusa-pro-green-800-spool.yaml
@@ -1,6 +1,7 @@
 uuid: b4dab637-472f-5ba7-9eb5-cebcfcb121fb
 slug: prusament-asa-prusa-pro-green-800-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-asa-prusa-pro-green-800g-nfc/
 material:
   slug: prusament-asa-prusa-pro-green
 nominal_netto_full_weight: 800

--- a/data/material-packages/prusament/prusament-asa-sapphire-blue-800-spool.yaml
+++ b/data/material-packages/prusament/prusament-asa-sapphire-blue-800-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 42b831b5-3f70-526c-9005-cf032e336e12
 slug: prusament-asa-sapphire-blue-800-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-asa-sapphire-blue-800g-nfc/
 material:
   slug: prusament-asa-sapphire-blue
 nominal_netto_full_weight: 800

--- a/data/material-packages/prusament/prusament-asa-signal-white-800-spool.yaml
+++ b/data/material-packages/prusament/prusament-asa-signal-white-800-spool.yaml
@@ -1,6 +1,7 @@
 uuid: d739306a-d829-5ecc-b634-9034bb20a6cd
 slug: prusament-asa-signal-white-800-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-asa-signal-white-800g-nfc/
 gtin: 8594173675414
 container:
   slug: prusament-spool-1kg

--- a/data/material-packages/prusament/prusament-pa11-carbon-fiber-black-800-spool.yaml
+++ b/data/material-packages/prusament/prusament-pa11-carbon-fiber-black-800-spool.yaml
@@ -1,6 +1,7 @@
 uuid: dbce6e57-0f26-5d4c-96ec-2779c5edf5d5
 slug: prusament-pa11-carbon-fiber-black-800-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pa11-carbon-fiber-black-800g-nfc/
 material:
   slug: prusament-pa11-carbon-fiber-black
 nominal_netto_full_weight: 800

--- a/data/material-packages/prusament/prusament-pc-blend-carbon-fiber-black-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pc-blend-carbon-fiber-black-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 12195a67-1e7b-548f-977e-f769fc9c3769
 slug: prusament-pc-blend-carbon-fiber-black-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pc-blend-carbon-fiber-black-2kg-nfc/
 material:
   slug: prusament-pc-blend-carbon-fiber-black
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-pc-blend-carbon-fiber-black-800-spool.yaml
+++ b/data/material-packages/prusament/prusament-pc-blend-carbon-fiber-black-800-spool.yaml
@@ -1,6 +1,7 @@
 uuid: ab69511f-64a8-554a-961e-705fd41c71db
 slug: prusament-pc-blend-carbon-fiber-black-800-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pc-blend-carbon-fiber-black-800g-nfc/
 material:
   slug: prusament-pc-blend-carbon-fiber-black
 nominal_netto_full_weight: 800

--- a/data/material-packages/prusament/prusament-pc-blend-jet-black-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pc-blend-jet-black-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 9c077daa-ea30-5f73-8555-98620c195285
 slug: prusament-pc-blend-jet-black-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pc-blend-jet-black-2kg-nfc/
 gtin: 8594173676718
 container:
   slug: prusament-spool-2kg

--- a/data/material-packages/prusament/prusament-pc-blend-jet-black-900-spool.yaml
+++ b/data/material-packages/prusament/prusament-pc-blend-jet-black-900-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 128bff32-2427-5831-90b7-ddb052f307da
 slug: prusament-pc-blend-jet-black-900-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pc-blend-jet-black-900g-nfc/
 gtin: 8594173675322
 container:
   slug: prusament-spool-1kg

--- a/data/material-packages/prusament/prusament-pc-blend-natural-900-spool.yaml
+++ b/data/material-packages/prusament/prusament-pc-blend-natural-900-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 80fa6cea-8862-5afc-bde5-d84ed6f547ed
 slug: prusament-pc-blend-natural-900-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pc-blend-natural-900g-nfc/
 material:
   slug: prusament-pc-blend-natural
 nominal_netto_full_weight: 900

--- a/data/material-packages/prusament/prusament-pc-blend-prusa-orange-900-spool.yaml
+++ b/data/material-packages/prusament/prusament-pc-blend-prusa-orange-900-spool.yaml
@@ -1,6 +1,7 @@
 uuid: d4504ba7-186d-5bfd-86dc-223ec02d3561
 slug: prusament-pc-blend-prusa-orange-900-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pc-blend-prusa-orange-900g-nfc/
 material:
   slug: prusament-pc-blend-prusa-orange
 nominal_netto_full_weight: 900

--- a/data/material-packages/prusament/prusament-pc-blend-prusa-pro-green-900-spool.yaml
+++ b/data/material-packages/prusament/prusament-pc-blend-prusa-pro-green-900-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 9d263312-57ca-591b-9980-08e15ad49c8d
 slug: prusament-pc-blend-prusa-pro-green-900-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pc-blend-prusa-pro-green-900g-nfc/
 gtin: 8594173675995
 container:
   slug: prusament-spool-1kg

--- a/data/material-packages/prusament/prusament-pc-blend-urban-grey-900-spool.yaml
+++ b/data/material-packages/prusament/prusament-pc-blend-urban-grey-900-spool.yaml
@@ -1,6 +1,7 @@
 uuid: c5635922-3eca-5164-be28-74463d15c2be
 slug: prusament-pc-blend-urban-grey-900-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pc-blend-urban-grey-900g-nfc/
 gtin: 8594173675339
 container:
   slug: prusament-spool-1kg

--- a/data/material-packages/prusament/prusament-pc-space-grade-black-850-spool.yaml
+++ b/data/material-packages/prusament/prusament-pc-space-grade-black-850-spool.yaml
@@ -1,6 +1,7 @@
 uuid: ffed4816-988e-5ebc-b189-719e8c8b620f
 slug: prusament-pc-space-grade-black-850-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pc-space-grade-black-850g/
 gtin: 8594173676350
 container:
   slug: prusament-spool-1kg

--- a/data/material-packages/prusament/prusament-pei-1010-natural-500-spool.yaml
+++ b/data/material-packages/prusament/prusament-pei-1010-natural-500-spool.yaml
@@ -1,6 +1,7 @@
 uuid: f896311f-648a-57ec-a97b-f17d46a1398f
 slug: prusament-pei-1010-natural-500-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pei-1010-natural-500g/
 material:
   slug: prusament-pei-1010-natural
 nominal_netto_full_weight: 500

--- a/data/material-packages/prusament/prusament-petg-anthracite-grey-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-anthracite-grey-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 18005665-562b-5228-935f-fb46d11b0b3f
 slug: prusament-petg-anthracite-grey-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-anthracite-grey-1kg-nfc/
 material:
   slug: prusament-petg-anthracite-grey
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-anthracite-grey-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-anthracite-grey-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 8e1a1b55-5543-5f93-8694-7e3e6cd30a57
 slug: prusament-petg-anthracite-grey-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-anthracite-grey-2kg-nfc/
 material:
   slug: prusament-petg-anthracite-grey
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-petg-anthracite-grey-900-refill.yaml
+++ b/data/material-packages/prusament/prusament-petg-anthracite-grey-900-refill.yaml
@@ -1,6 +1,7 @@
 uuid: b735919c-c296-57cb-94a3-8296dbf7536e
 slug: prusament-petg-anthracite-grey-900-refill
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-anthracite-grey-900g-refill-nfc-compatible/
 gtin: 8594173676152
 material:
   slug: prusament-petg-anthracite-grey

--- a/data/material-packages/prusament/prusament-petg-carbon-fiber-black-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-carbon-fiber-black-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 1646d7ae-d473-5b27-8fc3-1e8bb4700de7
 slug: prusament-petg-carbon-fiber-black-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-carbon-fiber-black-1kg-nfc/
 material:
   slug: prusament-petg-carbon-fiber-black
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-carmine-red-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-carmine-red-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 61d14d29-6548-5e98-88bb-fe054ac59ffb
 slug: prusament-petg-carmine-red-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-carmine-red-1kg-nfc/
 material:
   slug: prusament-petg-carmine-red
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-chalky-blue-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-chalky-blue-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 0e696528-c806-528a-9b25-ed36b8f5dfe1
 slug: prusament-petg-chalky-blue-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-chalky-blue-1kg-nfc/
 material:
   slug: prusament-petg-chalky-blue
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-clear-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-clear-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 2b525eb5-5830-550d-a707-8f26363c9bf9
 slug: prusament-petg-clear-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-clear-1kg-nfc/
 material:
   slug: prusament-petg-clear
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-clear-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-clear-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: f5e3b43e-b5f0-59a0-a076-f7677ecf951c
 slug: prusament-petg-clear-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-clear-2kg-nfc/
 material:
   slug: prusament-petg-clear
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-petg-clear-900-refill.yaml
+++ b/data/material-packages/prusament/prusament-petg-clear-900-refill.yaml
@@ -1,6 +1,7 @@
 uuid: 101f16c3-6c38-5485-8767-a614749d44af
 slug: prusament-petg-clear-900-refill
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-clear-900g-refill-nfc-compatible/
 gtin: 8594173676169
 material:
   slug: prusament-petg-clear

--- a/data/material-packages/prusament/prusament-petg-electric-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-electric-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 362e1502-f936-51d1-8316-7efb82151deb
 slug: prusament-petg-electric-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-electric-green-1kg-nfc/
 material:
   slug: prusament-petg-electric-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-emerald-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-emerald-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 2143a6f4-39bd-5fca-bb49-1064cfc7251d
 slug: prusament-petg-emerald-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-emerald-green-1kg-nfc/
 material:
   slug: prusament-petg-emerald-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-jet-black-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-jet-black-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 6f957b59-9725-5068-9102-15bb77807534
 slug: prusament-petg-jet-black-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-jet-black-1kg-nfc/
 material:
   slug: prusament-petg-jet-black
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-jet-black-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-jet-black-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 64a45805-015a-5689-9c01-667eee20b5f4
 slug: prusament-petg-jet-black-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-jet-black-2kg/
 material:
   slug: prusament-petg-jet-black
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-petg-jet-black-900-refill.yaml
+++ b/data/material-packages/prusament/prusament-petg-jet-black-900-refill.yaml
@@ -1,6 +1,7 @@
 uuid: d11723d5-1bee-54e4-bbe1-7dcea8501180
 slug: prusament-petg-jet-black-900-refill
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-jet-black-900g-refill-nfc-compatible/
 gtin: 8594173675780
 material:
   slug: prusament-petg-jet-black

--- a/data/material-packages/prusament/prusament-petg-jungle-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-jungle-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 77ab0489-8e18-5136-a3c5-b89f837a6822
 slug: prusament-petg-jungle-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-jungle-green-1kg-nfc/
 material:
   slug: prusament-petg-jungle-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-lipstick-red-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-lipstick-red-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: f453ec2a-9691-52c9-ad0b-78fb2b630331
 slug: prusament-petg-lipstick-red-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-lipstick-red-1kg-nfc/
 material:
   slug: prusament-petg-lipstick-red
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-magnetite-40-grey-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-magnetite-40-grey-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 41351ab0-7622-5624-90a8-37c5236dbdcb
 slug: prusament-petg-magnetite-40-grey-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-magnetite-40-grey-1kg-nfc/
 material:
   slug: prusament-petg-magnetite-40-grey
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-mango-yellow-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-mango-yellow-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 775fcf26-be3f-56ce-8ccf-502e077e9e91
 slug: prusament-petg-mango-yellow-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-mango-yellow-1kg-nfc/
 material:
   slug: prusament-petg-mango-yellow
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-matte-black-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-matte-black-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: f3ed755f-70b1-54bc-9dff-4a3727e243db
 slug: prusament-petg-matte-black-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-matte-black-1kg-nfc/
 material:
   slug: prusament-petg-matte-black
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-neon-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-neon-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 772e971f-27b5-58bd-9f61-1fd0385c1c38
 slug: prusament-petg-neon-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-neon-green-1kg-nfc/
 material:
   slug: prusament-petg-neon-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-ocean-blue-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-ocean-blue-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 7ba7dbe7-23d2-5893-a887-d4027872796f
 slug: prusament-petg-ocean-blue-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-ocean-blue-1kg-nfc/
 material:
   slug: prusament-petg-ocean-blue
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-orange-for-ppe-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-orange-for-ppe-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: ef203e1b-bc58-5e19-95d3-2897c6053ce5
 slug: prusament-petg-orange-for-ppe-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-orange-for-ppe-1kg-2/
 material:
   slug: prusament-petg-orange-for-ppe
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-pistachio-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-pistachio-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: e2302824-759f-5b6a-a194-45607bed3ecb
 slug: prusament-petg-pistachio-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-pistachio-green-1kg-nfc/
 material:
   slug: prusament-petg-pistachio-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-prusa-galaxy-black-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-prusa-galaxy-black-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 607e6d9b-82d6-5b05-8f94-43248ae19e89
 slug: prusament-petg-prusa-galaxy-black-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-prusa-galaxy-black-1kg-nfc/
 material:
   slug: prusament-petg-prusa-galaxy-black
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-prusa-galaxy-black-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-prusa-galaxy-black-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: c7d7db70-84f4-5e91-880a-e9c02981cd1c
 slug: prusament-petg-prusa-galaxy-black-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-galaxy-black-2kg-nfc/
 gtin: 8594173676725
 container:
   slug: prusament-spool-2kg

--- a/data/material-packages/prusament/prusament-petg-prusa-galaxy-black-900-refill.yaml
+++ b/data/material-packages/prusament/prusament-petg-prusa-galaxy-black-900-refill.yaml
@@ -1,6 +1,7 @@
 uuid: fc5ccb59-186e-5570-8d86-179c7c61c362
 slug: prusament-petg-prusa-galaxy-black-900-refill
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-prusa-galaxy-black-900g-refill-nfc-compatible/
 gtin: 8594173676053
 material:
   slug: prusament-petg-prusa-galaxy-black

--- a/data/material-packages/prusament/prusament-petg-prusa-orange-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-prusa-orange-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: ca7deb36-51fb-56ce-82f3-f118ca160adb
 slug: prusament-petg-prusa-orange-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-prusa-orange-1kg-nfc/
 material:
   slug: prusament-petg-prusa-orange
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-prusa-orange-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-prusa-orange-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 404679ef-cc40-522e-a287-70f6fe1d18b7
 slug: prusament-petg-prusa-orange-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-prusa-orange-2kg-nfc/
 material:
   slug: prusament-petg-prusa-orange
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-petg-prusa-orange-transparent-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-prusa-orange-transparent-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: fd13b810-0322-5de2-a237-0139c5c009f0
 slug: prusament-petg-prusa-orange-transparent-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-prusa-orange-transparent-1kg-nfc/
 material:
   slug: prusament-petg-prusa-orange-transparent
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-prusa-pro-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-prusa-pro-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 5562ae98-464a-59eb-9f98-01bdcb3818dc
 slug: prusament-petg-prusa-pro-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-prusa-pro-green-1kg/
 material:
   slug: prusament-petg-prusa-pro-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-recycled-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-recycled-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: a430802f-28b4-5e11-a97a-effd67df6748
 slug: prusament-petg-recycled-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-recycled-2kg-nfc/
 material:
   slug: prusament-petg-recycled
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-petg-recycled-black-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-recycled-black-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 198437df-0fc8-50be-b08d-1c52452ce2da
 slug: prusament-petg-recycled-black-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-recycled-black-2kg-nfc/
 gtin: 8594173676220
 container:
   slug: prusament-spool-2kg

--- a/data/material-packages/prusament/prusament-petg-shimmering-violet-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-shimmering-violet-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 17b11a9a-fd6d-5147-a8bb-fa6ad5085fd2
 slug: prusament-petg-shimmering-violet-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-shimmering-violet-1kg/
 material:
   slug: prusament-petg-shimmering-violet
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-signal-white-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-signal-white-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: ae2e6f70-2917-5dd0-ad9f-aa052c8cae33
 slug: prusament-petg-signal-white-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-signal-white-1kg-nfc/
 material:
   slug: prusament-petg-signal-white
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-signal-white-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-signal-white-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 1b5de5fa-91d6-58d5-a910-daa8609116a7
 slug: prusament-petg-signal-white-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-signal-white-2kg/
 material:
   slug: prusament-petg-signal-white
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-petg-signal-white-900-refill.yaml
+++ b/data/material-packages/prusament/prusament-petg-signal-white-900-refill.yaml
@@ -1,6 +1,7 @@
 uuid: 9d3d4c23-b15c-53a2-b919-fbdf70d80790
 slug: prusament-petg-signal-white-900-refill
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-signal-white-900g-refill-nfc-compatible/
 gtin: 8594173675735
 material:
   slug: prusament-petg-signal-white

--- a/data/material-packages/prusament/prusament-petg-sky-blue-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-sky-blue-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: f57c263b-4bd7-5ab8-ad94-ba57e027491b
 slug: prusament-petg-sky-blue-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-sky-blue-1kg-nfc/
 material:
   slug: prusament-petg-sky-blue
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-terracotta-light-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-terracotta-light-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 40bfc3ba-3f0e-55f3-8409-84739bd50507
 slug: prusament-petg-terracotta-light-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-terracotta-light-1kg-nfc/
 material:
   slug: prusament-petg-terracotta-light
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-tungsten-75-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-tungsten-75-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: a93f3bd0-e674-54f5-94fc-20842ce2f01f
 slug: prusament-petg-tungsten-75-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-tungsten-75-1kg-nfc/
 material:
   slug: prusament-petg-tungsten-75
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-ultraglow-green-25g.yaml
+++ b/data/material-packages/prusament/prusament-petg-ultraglow-green-25g.yaml
@@ -1,6 +1,7 @@
 uuid: de145515-d843-51f1-ace7-90bf428cd3e4
 slug: prusament-petg-ultraglow-green-25g
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-ultraglow-green-25g-sample/
 material:
   slug: prusament-petg-ultraglow-green
 nominal_netto_full_weight: 25

--- a/data/material-packages/prusament/prusament-petg-ultraglow-green-800-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-ultraglow-green-800-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 7f0a85b2-e90c-51f9-9210-11f8073ce190
 slug: prusament-petg-ultraglow-green-800-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-ultraglow-green-800g-nfc/
 material:
   slug: prusament-petg-ultraglow-green
 nominal_netto_full_weight: 800

--- a/data/material-packages/prusament/prusament-petg-ultramarine-blue-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-ultramarine-blue-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: b8b964c8-c292-52c6-96ca-37e1a7048a82
 slug: prusament-petg-ultramarine-blue-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-ultramarine-blue-1kg-nfc/
 material:
   slug: prusament-petg-ultramarine-blue
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-urban-grey-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-urban-grey-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: a12a3c11-fe6e-5156-863e-0a98022ec7bb
 slug: prusament-petg-urban-grey-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-urban-grey-1kg-nfc/
 material:
   slug: prusament-petg-urban-grey
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-urban-grey-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-urban-grey-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 5837151e-40b2-58eb-a6e8-6b23fa3e7a20
 slug: prusament-petg-urban-grey-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-urban-grey-2kg/
 material:
   slug: prusament-petg-urban-grey
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-petg-urban-grey-900-refill.yaml
+++ b/data/material-packages/prusament/prusament-petg-urban-grey-900-refill.yaml
@@ -1,6 +1,7 @@
 uuid: b638dc97-aa56-5032-8263-471258676516
 slug: prusament-petg-urban-grey-900-refill
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-urban-grey-900g-refill-nfc-compatible/
 gtin: 8594173676046
 material:
   slug: prusament-petg-urban-grey

--- a/data/material-packages/prusament/prusament-petg-v0-jet-black-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-v0-jet-black-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 914e1834-e4b8-576f-a82e-eaaddf7a7b32
 slug: prusament-petg-v0-jet-black-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-v0-jet-black-1kg/
 material:
   slug: prusament-petg-v0-jet-black
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-v0-natural-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-v0-natural-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 64e5ad9e-0c08-540e-9e56-19c2033ccdc7
 slug: prusament-petg-v0-natural-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-v0-natural-1kg/
 material:
   slug: prusament-petg-v0-natural
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-petg-yellow-gold-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-petg-yellow-gold-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: b9a81d73-52a2-5ec7-b62f-307013d2f176
 slug: prusament-petg-yellow-gold-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-petg-yellow-gold-1kg-nfc/
 material:
   slug: prusament-petg-yellow-gold
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-anniversary-le-2025-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-anniversary-le-2025-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: bb92c8cd-f567-522c-81ba-242b53478237
 slug: prusament-pla-anniversary-le-2025-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-anniversary-le-2025-1kg/
 gtin: 8594173676428
 container:
   slug: prusament-spool-1kg

--- a/data/material-packages/prusament/prusament-pla-anthracite-grey-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-anthracite-grey-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 514a655e-4843-5c6a-a0f2-1b9647e73053
 slug: prusament-pla-anthracite-grey-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-anthracite-grey-1kg/
 material:
   slug: prusament-pla-anthracite-grey
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-army-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-army-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 147eda5e-ea60-5480-8940-6a1c95b5f1f7
 slug: prusament-pla-army-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-army-green-1kg-nfc/
 material:
   slug: prusament-pla-army-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-army-green-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-army-green-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 8c3b6fe3-d8ad-59be-8c03-92c11f87abb3
 slug: prusament-pla-army-green-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-army-green-2kg-nfc/
 material:
   slug: prusament-pla-army-green
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-pla-azure-blue-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-azure-blue-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 1fbf4763-4cf8-5f4c-9cc9-4eb8b47ce254
 slug: prusament-pla-azure-blue-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-azure-blue-1kg-nfc/
 material:
   slug: prusament-pla-azure-blue
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-azure-blue-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-azure-blue-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: d1678e50-b48b-56dc-91e6-db6e185f8487
 slug: prusament-pla-azure-blue-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-azure-blue-2kg/
 material:
   slug: prusament-pla-azure-blue
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-pla-azure-blue-900-refill.yaml
+++ b/data/material-packages/prusament/prusament-pla-azure-blue-900-refill.yaml
@@ -1,6 +1,7 @@
 uuid: 340c74be-2742-536b-af3e-57a3bbdfd01b
 slug: prusament-pla-azure-blue-900-refill
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-azure-blue-900g-refill-nfc-compatible/
 gtin: 8594173676183
 material:
   slug: prusament-pla-azure-blue

--- a/data/material-packages/prusament/prusament-pla-blend-lime-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-blend-lime-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: de417797-7360-5d08-85c7-0d3438fdf945
 slug: prusament-pla-blend-lime-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-blend-lime-green-1kg-nfc/
 material:
   slug: prusament-pla-blend-lime-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-blend-ms-pink-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-blend-ms-pink-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: c5800342-3f2e-52c2-8f56-bc5b81eda962
 slug: prusament-pla-blend-ms-pink-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-blend-ms-pink-1kg-nfc/
 material:
   slug: prusament-pla-blend-ms-pink
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-blend-my-silverness-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-blend-my-silverness-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: add3f3fc-65d3-5c8f-8f12-8fb3dd0e3ed8
 slug: prusament-pla-blend-my-silverness-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-blend-my-silverness-1kg-nfc/
 material:
   slug: prusament-pla-blend-my-silverness
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-blend-oh-my-gold-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-blend-oh-my-gold-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 3c8818db-53ab-50b6-9d5f-60310886b4b3
 slug: prusament-pla-blend-oh-my-gold-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-blend-oh-my-gold-1kg-nfc/
 material:
   slug: prusament-pla-blend-oh-my-gold
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-blend-pearl-white-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-blend-pearl-white-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: d0551f81-76ca-5ce4-83ff-9a8795ae2e09
 slug: prusament-pla-blend-pearl-white-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-blend-pearl-white-1kg-nfc/
 material:
   slug: prusament-pla-blend-pearl-white
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-blend-royal-blue-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-blend-royal-blue-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 1c144905-a032-52f2-9ccb-c9ab1dae07c5
 slug: prusament-pla-blend-royal-blue-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-blend-royal-blue-1kg-nfc/
 material:
   slug: prusament-pla-blend-royal-blue
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-blend-viva-la-bronze-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-blend-viva-la-bronze-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 5d73a040-77c9-55ee-95bc-f4ef0fc2efda
 slug: prusament-pla-blend-viva-la-bronze-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-blend-viva-la-bronze-1kg-nfc/
 material:
   slug: prusament-pla-blend-viva-la-bronze
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-blood-red-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-blood-red-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: dda59e4e-a86f-506e-9a73-d3ad87470697
 slug: prusament-pla-blood-red-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-blood-red-1kg/
 material:
   slug: prusament-pla-blood-red
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-chalky-blue-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-chalky-blue-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 595cefd2-c7ee-5eda-9e17-562eb358b1d6
 slug: prusament-pla-chalky-blue-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-chalky-blue-1kg/
 material:
   slug: prusament-pla-chalky-blue
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-electric-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-electric-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 5f36229b-6a7d-5edd-b710-b0f289f60c79
 slug: prusament-pla-electric-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-electric-green-1kg-nfc/
 material:
   slug: prusament-pla-electric-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-emerald-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-emerald-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: e61931aa-97de-562c-850b-f0c63ecb7c4f
 slug: prusament-pla-emerald-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-emerald-green-1kg-nfc/
 material:
   slug: prusament-pla-emerald-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-galaxy-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-galaxy-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 93bac788-6ecd-5358-b4ae-edca77b77547
 slug: prusament-pla-galaxy-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-galaxy-green-1kg-nfc/
 material:
   slug: prusament-pla-galaxy-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-galaxy-purple-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-galaxy-purple-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 458a82c3-7f5a-5c3d-92a5-152951c12813
 slug: prusament-pla-galaxy-purple-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-galaxy-purple-1kg-nfc/
 material:
   slug: prusament-pla-galaxy-purple
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-galaxy-purple-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-galaxy-purple-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 5e9a4a79-0c35-52a4-85ec-32a97e9c70b3
 slug: prusament-pla-galaxy-purple-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-galaxy-purple-2kg/
 material:
   slug: prusament-pla-galaxy-purple
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-pla-galaxy-red-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-galaxy-red-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 7cd1b29c-f78a-5fcf-888a-73299f47d4ac
 slug: prusament-pla-galaxy-red-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-galaxy-red-1kg-nfc/
 material:
   slug: prusament-pla-galaxy-red
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-galaxy-silver-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-galaxy-silver-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 3131b827-cb3d-53a8-b078-61822ee2bf63
 slug: prusament-pla-galaxy-silver-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-galaxy-silver-1kg-nfc/
 material:
   slug: prusament-pla-galaxy-silver
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-galaxy-silver-900-refill.yaml
+++ b/data/material-packages/prusament/prusament-pla-galaxy-silver-900-refill.yaml
@@ -1,6 +1,7 @@
 uuid: bbcafbd6-3361-57f4-bdb1-a8eed7fc2bfa
 slug: prusament-pla-galaxy-silver-900-refill
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-galaxy-silver-900g-refill-nfc-compatible/
 gtin: 8594173676039
 material:
   slug: prusament-pla-galaxy-silver

--- a/data/material-packages/prusament/prusament-pla-gentlemans-grey-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-gentlemans-grey-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 56f8b4f2-e2c6-5809-9317-227c2e175a5d
 slug: prusament-pla-gentlemans-grey-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-gentleman-s-grey-1kg-nfc/
 material:
   slug: prusament-pla-gentlemans-grey
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-gravity-grey-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-gravity-grey-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 81c7588f-c441-5d97-8628-fde7223c9388
 slug: prusament-pla-gravity-grey-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-gravity-grey-1kg-nfc/
 material:
   slug: prusament-pla-gravity-grey
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-gravity-grey-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-gravity-grey-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 6d8415b5-0708-5fc7-bb38-7daf536d203f
 slug: prusament-pla-gravity-grey-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-gravity-grey-2kg/
 material:
   slug: prusament-pla-gravity-grey
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-pla-jet-black-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-jet-black-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 1303a117-1666-5530-94f1-187960b78cb4
 slug: prusament-pla-jet-black-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-jet-black-1kg-nfc/
 material:
   slug: prusament-pla-jet-black
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-jet-black-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-jet-black-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: a4fd547d-afac-5185-bd3a-921a945ee32a
 slug: prusament-pla-jet-black-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-jet-black-2kg/
 material:
   slug: prusament-pla-jet-black
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-pla-jet-black-900-refill.yaml
+++ b/data/material-packages/prusament/prusament-pla-jet-black-900-refill.yaml
@@ -1,6 +1,7 @@
 uuid: efe4af41-79f1-534f-a590-434649fe033c
 slug: prusament-pla-jet-black-900-refill
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-jet-black-900g-refill-nfc-compatible/
 gtin: 8594173676060
 material:
   slug: prusament-pla-jet-black

--- a/data/material-packages/prusament/prusament-pla-lipstick-red-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-lipstick-red-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 9f8b227c-ec5d-5fd1-947b-459ba300c6c9
 slug: prusament-pla-lipstick-red-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-lipstick-red-1kg-nfc/
 material:
   slug: prusament-pla-lipstick-red
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-lipstick-red-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-lipstick-red-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 25867fb5-ee5c-5ecd-ac24-9e2f0b3cc95a
 slug: prusament-pla-lipstick-red-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-lipstick-red-2kg-nfc/
 material:
   slug: prusament-pla-lipstick-red
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-pla-marble-grey-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-marble-grey-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: d5aef2de-aaca-56e5-9b79-cf8afe23d775
 slug: prusament-pla-marble-grey-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-marble-grey-1kg-nfc/
 material:
   slug: prusament-pla-marble-grey
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-mystic-brown-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-mystic-brown-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: f66c6181-b310-5cfa-ba55-0025edcf7de4
 slug: prusament-pla-mystic-brown-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-premium-pla-mystic-brown-1kg-2/
 material:
   slug: prusament-pla-mystic-brown
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-mystic-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-mystic-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 40822982-1aaa-5df8-857e-54894c4db65f
 slug: prusament-pla-mystic-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-premium-pla-mystic-green-1kg-2/
 material:
   slug: prusament-pla-mystic-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-natural-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-natural-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: ac68f686-ca26-5790-97c3-a8a785184fd4
 slug: prusament-pla-natural-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-natural-1kg-nfc/
 material:
   slug: prusament-pla-natural
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-noctua-beige-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-noctua-beige-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: b4f3a442-deff-5791-a2a6-a098c67765ed
 slug: prusament-pla-noctua-beige-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-noctua-beige-1kg-nfc/
 material:
   slug: prusament-pla-noctua-beige
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-noctua-brown-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-noctua-brown-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 4dcc8d7b-1d0c-5abe-9652-9e69699f4aae
 slug: prusament-pla-noctua-brown-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-noctua-brown-1kg-nfc/
 material:
   slug: prusament-pla-noctua-brown
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-opal-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-opal-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 35207a6d-f5ab-5f34-9839-fd30e1678121
 slug: prusament-pla-opal-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-opal-green-1kg-nfc/
 material:
   slug: prusament-pla-opal-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-pearl-mouse-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-pearl-mouse-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 6a20c72d-29c2-5859-ae7d-c7d6d3b2fd58
 slug: prusament-pla-pearl-mouse-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-pearl-mouse-1kg-nfc/
 material:
   slug: prusament-pla-pearl-mouse
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-pineapple-yellow-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-pineapple-yellow-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 2ed792eb-fb66-5ef4-b49a-417e2b2422e7
 slug: prusament-pla-pineapple-yellow-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-pineapple-yellow-1kg-nfc/
 material:
   slug: prusament-pla-pineapple-yellow
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-pistachio-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-pistachio-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 84fe09b6-4bed-59c1-be67-03804eacaf38
 slug: prusament-pla-pistachio-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-pistachio-green-1kg/
 material:
   slug: prusament-pla-pistachio-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-pristine-white-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-pristine-white-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 6b6dc124-afa8-5be2-9df6-1b32df20c8df
 slug: prusament-pla-pristine-white-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-pristine-white-1kg-nfc/
 material:
   slug: prusament-pla-pristine-white
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-pristine-white-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-pristine-white-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 3b8f29d3-d279-5ffd-9b7c-d6c30114fa26
 slug: prusament-pla-pristine-white-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-pristine-white-2kg-2/
 material:
   slug: prusament-pla-pristine-white
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-pla-pristine-white-900-refill.yaml
+++ b/data/material-packages/prusament/prusament-pla-pristine-white-900-refill.yaml
@@ -1,6 +1,7 @@
 uuid: ceb986ff-01f1-5e15-8632-fb51fa7205ff
 slug: prusament-pla-pristine-white-900-refill
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-pristine-white-900g-refill-nfc-compatible/
 gtin: 8594173676176
 material:
   slug: prusament-pla-pristine-white

--- a/data/material-packages/prusament/prusament-pla-prusa-galaxy-black-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-prusa-galaxy-black-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 6e0aece2-1daf-5f2a-ba20-697968ec7d14
 slug: prusament-pla-prusa-galaxy-black-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-prusa-galaxy-black-1kg-nfc/
 material:
   slug: prusament-pla-prusa-galaxy-black
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-prusa-galaxy-black-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-prusa-galaxy-black-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 2e907c5b-1df4-59ee-a1ae-d705674e1352
 slug: prusament-pla-prusa-galaxy-black-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-prusa-galaxy-black-2kg-nfc/
 material:
   slug: prusament-pla-prusa-galaxy-black
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-pla-prusa-galaxy-black-900-refill.yaml
+++ b/data/material-packages/prusament/prusament-pla-prusa-galaxy-black-900-refill.yaml
@@ -1,6 +1,7 @@
 uuid: 5c4ff282-a282-5d12-a6b4-c620a2b61956
 slug: prusament-pla-prusa-galaxy-black-900-refill
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-prusa-galaxy-black-900g-refill-nfc-compatible/
 gtin: 8594173675773
 material:
   slug: prusament-pla-prusa-galaxy-black

--- a/data/material-packages/prusament/prusament-pla-prusa-orange-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-prusa-orange-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 6b9c7b1d-0ebe-5177-a6a7-4e3aa38d0a3b
 slug: prusament-pla-prusa-orange-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-prusa-orange-1kg-nfc/
 material:
   slug: prusament-pla-prusa-orange
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-prusa-orange-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-prusa-orange-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 919e312c-4e6e-5867-b519-a786dd03d2d1
 slug: prusament-pla-prusa-orange-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-prusa-orange-2kg/
 material:
   slug: prusament-pla-prusa-orange
 nominal_netto_full_weight: 2000

--- a/data/material-packages/prusament/prusament-pla-prusa-pro-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-prusa-pro-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 52d917e0-6da4-5184-8ef3-4ff1d565d36a
 slug: prusament-pla-prusa-pro-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-prusa-pro-green-1kg/
 material:
   slug: prusament-pla-prusa-pro-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-recycled-2000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-recycled-2000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 281ce165-ceeb-5ff7-9661-8dfb67e3edb9
 slug: prusament-pla-recycled-2000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-recycled-2kg/
 gtin: 8594173675667
 container:
   slug: prusament-spool-2kg

--- a/data/material-packages/prusament/prusament-pla-simply-green-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-simply-green-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: a6a0ee76-93dd-58c8-85db-002d1c376d6c
 slug: prusament-pla-simply-green-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-simply-green-1kg-nfc/
 material:
   slug: prusament-pla-simply-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-vanilla-white-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-pla-vanilla-white-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 789e417c-4e69-5704-96f8-8d1d14312d6f
 slug: prusament-pla-vanilla-white-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-vanilla-white-1kg-nfc/
 material:
   slug: prusament-pla-vanilla-white
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-pla-vanilla-white-900-refill.yaml
+++ b/data/material-packages/prusament/prusament-pla-vanilla-white-900-refill.yaml
@@ -1,6 +1,7 @@
 uuid: f6deb696-64b9-5608-9302-f0977531f777
 slug: prusament-pla-vanilla-white-900-refill
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pla-vanilla-white-900g-refill-nfc-compatible/
 gtin: 8594173676077
 material:
   slug: prusament-pla-vanilla-white

--- a/data/material-packages/prusament/prusament-pp-carbon-fiber-black-650-spool.yaml
+++ b/data/material-packages/prusament/prusament-pp-carbon-fiber-black-650-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 34a1f8ad-828f-5296-93ff-f337a64492c6
 slug: prusament-pp-carbon-fiber-black-650-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pp-carbon-fiber-black-650g-nfc/
 material:
   slug: prusament-pp-carbon-fiber-black
 nominal_netto_full_weight: 650

--- a/data/material-packages/prusament/prusament-pp-glass-fiber-natural-850-spool.yaml
+++ b/data/material-packages/prusament/prusament-pp-glass-fiber-natural-850-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 416a7570-8c1e-5de6-93d7-28cc0170ea00
 slug: prusament-pp-glass-fiber-natural-850-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pp-glass-fiber-natural-850g/
 material:
   slug: prusament-pp-glass-fiber-natural
 nominal_netto_full_weight: 850

--- a/data/material-packages/prusament/prusament-pvb-bright-green-500-spool.yaml
+++ b/data/material-packages/prusament/prusament-pvb-bright-green-500-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 3f901591-86fd-5596-a324-bbddc446396f
 slug: prusament-pvb-bright-green-500-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pvb-bright-green-transparent-500g/
 material:
   slug: prusament-pvb-bright-green
 nominal_netto_full_weight: 500

--- a/data/material-packages/prusament/prusament-pvb-dark-blue-500-spool.yaml
+++ b/data/material-packages/prusament/prusament-pvb-dark-blue-500-spool.yaml
@@ -1,6 +1,7 @@
 uuid: f4cd2cd4-24db-5d6a-8a60-a4ba6dbb55bc
 slug: prusament-pvb-dark-blue-500-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pvb-dark-blue-transparent-500g/
 material:
   slug: prusament-pvb-dark-blue
 nominal_netto_full_weight: 500

--- a/data/material-packages/prusament/prusament-pvb-light-yellow-500-spool.yaml
+++ b/data/material-packages/prusament/prusament-pvb-light-yellow-500-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 36b11d19-2b13-5fdd-b66b-f046ecf14b35
 slug: prusament-pvb-light-yellow-500-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pvb-light-yellow-transparent-500g/
 material:
   slug: prusament-pvb-light-yellow
 nominal_netto_full_weight: 500

--- a/data/material-packages/prusament/prusament-pvb-natural-500-spool.yaml
+++ b/data/material-packages/prusament/prusament-pvb-natural-500-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 365f28b3-f2f8-5c8d-b743-cf1d7a8b1388
 slug: prusament-pvb-natural-500-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pvb-natural-transparent-500g/
 material:
   slug: prusament-pvb-natural
 nominal_netto_full_weight: 500

--- a/data/material-packages/prusament/prusament-pvb-prusa-orange-500-spool.yaml
+++ b/data/material-packages/prusament/prusament-pvb-prusa-orange-500-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 3013d148-d05d-560f-bb61-e7dbc3452355
 slug: prusament-pvb-prusa-orange-500-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pvb-prusa-orange-transparent-500g/
 material:
   slug: prusament-pvb-prusa-orange
 nominal_netto_full_weight: 500

--- a/data/material-packages/prusament/prusament-pvb-smoky-black-500-spool.yaml
+++ b/data/material-packages/prusament/prusament-pvb-smoky-black-500-spool.yaml
@@ -1,6 +1,7 @@
 uuid: a68e723b-4943-5646-b2cd-622f2983ee12
 slug: prusament-pvb-smoky-black-500-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-pvb-smoky-black-transparent-500g/
 material:
   slug: prusament-pvb-smoky-black
 nominal_netto_full_weight: 500

--- a/data/material-packages/prusament/prusament-rpla-algae-pigment-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-rpla-algae-pigment-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: c8715bfb-e0e2-5a11-8154-47adf2e7a1db
 slug: prusament-rpla-algae-pigment-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-rpla-algae-pigment-1kg-nfc/
 material:
   slug: prusament-rpla-algae-pigment
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-rpla-corn-pigment-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-rpla-corn-pigment-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 5750e46f-33e1-5e82-b5fe-c76b6311fe65
 slug: prusament-rpla-corn-pigment-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-rpla-corn-pigment-1kg-nfc/
 material:
   slug: prusament-rpla-corn-pigment
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-rpla-risotto-pigment-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-rpla-risotto-pigment-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: bbfd5c19-d82e-5269-b0b1-99ad1e1132e3
 slug: prusament-rpla-risotto-pigment-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-rpla-risotto-pigment-1kg-nfc/
 material:
   slug: prusament-rpla-risotto-pigment
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-rpla-wine-pigment-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-rpla-wine-pigment-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: d5176cc4-0f6b-5c56-bf02-adac920b789f
 slug: prusament-rpla-wine-pigment-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-rpla-wine-pigment-1kg-nfc/
 material:
   slug: prusament-rpla-wine-pigment
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-tpu-95a-jet-black-500-spool.yaml
+++ b/data/material-packages/prusament/prusament-tpu-95a-jet-black-500-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 4bed1113-9323-5a6e-aad2-3faaf4c8c2ab
 slug: prusament-tpu-95a-jet-black-500-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-tpu-95a-jet-black-500g-nfc/
 material:
   slug: prusament-tpu-95a-jet-black
 nominal_netto_full_weight: 500

--- a/data/material-packages/prusament/prusament-tpu-95a-lipstick-red-500-spool.yaml
+++ b/data/material-packages/prusament/prusament-tpu-95a-lipstick-red-500-spool.yaml
@@ -1,6 +1,7 @@
 uuid: ba024ce8-5545-5824-a03c-3c4dd02302a5
 slug: prusament-tpu-95a-lipstick-red-500-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-tpu-95a-lipstick-red-500g-nfc/
 material:
   slug: prusament-tpu-95a-lipstick-red
 nominal_netto_full_weight: 500

--- a/data/material-packages/prusament/prusament-tpu-95a-natural-500-spool.yaml
+++ b/data/material-packages/prusament/prusament-tpu-95a-natural-500-spool.yaml
@@ -1,6 +1,7 @@
 uuid: a8f1e1cb-2dc9-5cdb-91cf-dd9fa03932a5
 slug: prusament-tpu-95a-natural-500-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-tpu-95a-natural-500g/
 material:
   slug: prusament-tpu-95a-natural
 nominal_netto_full_weight: 500

--- a/data/material-packages/prusament/prusament-tpu-95a-ultramarine-blue-500-spool.yaml
+++ b/data/material-packages/prusament/prusament-tpu-95a-ultramarine-blue-500-spool.yaml
@@ -1,6 +1,7 @@
 uuid: ad46b319-2a34-544b-ac4d-6f6b83899689
 slug: prusament-tpu-95a-ultramarine-blue-500-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-tpu-95a-ultramarine-blue-500g-nfc/
 material:
   slug: prusament-tpu-95a-ultramarine-blue
 nominal_netto_full_weight: 500

--- a/data/material-packages/prusament/prusament-woodfill-chocolate-brown-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-woodfill-chocolate-brown-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: 0b6ff0ee-0c10-5e89-abdf-c822b12c6e10
 slug: prusament-woodfill-chocolate-brown-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-woodfill-chocolate-brown-1kg/
 material:
   slug: prusament-woodfill-chocolate-brown
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-woodfill-linden-light-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-woodfill-linden-light-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: d0b633ba-461c-52ec-855b-62406eec4701
 slug: prusament-woodfill-linden-light-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-woodfill-linden-light-1kg/
 material:
   slug: prusament-woodfill-linden-light
 nominal_netto_full_weight: 1000

--- a/data/material-packages/prusament/prusament-woodfill-pastel-brown-1000-spool.yaml
+++ b/data/material-packages/prusament/prusament-woodfill-pastel-brown-1000-spool.yaml
@@ -1,6 +1,7 @@
 uuid: ac5d4988-9d73-5c92-9508-459f9e782f6b
 slug: prusament-woodfill-pastel-brown-1000-spool
 class: FFF
+url: https://www.prusa3d.com/product/prusament-woodfill-pastel-brown-1kg/
 material:
   slug: prusament-woodfill-pastel-brown
 nominal_netto_full_weight: 1000


### PR DESCRIPTION
Adds the url field to all 142 current Prusament packages (new spools + refills + one sample), each pointing to its specific prusa3d.com SKU page matched by weight and type (1kg/2kg spools, 800g/900g/650g/500g 
  spools, 900g NFC-compatible refills, 25g sample). NFC store page preferred where available. All URLs verified live against the store. Legacy old-spool/old-refill SKUs and resins excluded. Schema validation 
  passes.
