### PR TITLE
Add properties for addnorth PETG materials

### DIFF
--- a/data/materials/addnorth/addnorth-petg-clear.yaml
+++ b/data/materials/addnorth/addnorth-petg-clear.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/addnorth/addnorth-petg-clear/b4be9b922f90.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 225
+  max_print_temperature: 260
+  min_bed_temperature: 0
+  max_bed_temperature: 80

--- a/data/materials/addnorth/addnorth-petg-glitz-grey.yaml
+++ b/data/materials/addnorth/addnorth-petg-glitz-grey.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/addnorth/addnorth-petg-glitz-grey/7b728691feb6.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 225
+  max_print_temperature: 260
+  min_bed_temperature: 0
+  max_bed_temperature: 80

--- a/data/materials/addnorth/addnorth-petg-green.yaml
+++ b/data/materials/addnorth/addnorth-petg-green.yaml
@@ -11,4 +11,9 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/addnorth/addnorth-petg-green/e0f5c394943b.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 225
+  max_print_temperature: 260
+  min_bed_temperature: 0
+  max_bed_temperature: 80

--- a/data/materials/addnorth/addnorth-petg-grey.yaml
+++ b/data/materials/addnorth/addnorth-petg-grey.yaml
@@ -11,4 +11,9 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/addnorth/addnorth-petg-grey/0c1ad088450a.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 225
+  max_print_temperature: 260
+  min_bed_temperature: 0
+  max_bed_temperature: 80

--- a/data/materials/addnorth/addnorth-petg-lucent-orange.yaml
+++ b/data/materials/addnorth/addnorth-petg-lucent-orange.yaml
@@ -11,4 +11,9 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/addnorth/addnorth-petg-lucent-orange/72184245c10a.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 225
+  max_print_temperature: 260
+  min_bed_temperature: 0
+  max_bed_temperature: 80

--- a/data/materials/addnorth/addnorth-petg-medium-blue.yaml
+++ b/data/materials/addnorth/addnorth-petg-medium-blue.yaml
@@ -11,4 +11,9 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/addnorth/addnorth-petg-medium-blue/d4d9f121fd06.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 225
+  max_print_temperature: 260
+  min_bed_temperature: 0
+  max_bed_temperature: 80

--- a/data/materials/addnorth/addnorth-petg-red.yaml
+++ b/data/materials/addnorth/addnorth-petg-red.yaml
@@ -11,4 +11,9 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/addnorth/addnorth-petg-red/cc2af9f84079.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 225
+  max_print_temperature: 260
+  min_bed_temperature: 0
+  max_bed_temperature: 80


### PR DESCRIPTION
Add properties for add:north PETG materials
Properties added:

- density
- min_print_temperature
- max_print_temperature
- min_bed_temperature
- max_bed_temperature
Values were taken from the official add:north product pages.

Thios should be the last for Addnorth standard PETG