### PR TITLE
Update ELEGOO RAPID PLA Plus filaments; add ELEGOO cardboard spool etc.

### DIFF
--- a/data/material-containers/elegoo-cardboard-spool-1kg.yaml
+++ b/data/material-containers/elegoo-cardboard-spool-1kg.yaml
@@ -1,0 +1,10 @@
+uuid: 53bc78b9-d70f-45cd-a4ec-6db1035100e8
+slug: elegoo-cardboard-spool-1kg
+name: ELEGOO Cardboard Spool 1kg
+class: FFF
+brand:
+  slug: elegoo
+hole_diameter: 54
+outer_diameter: 200
+width: 65
+empty_weight: 154

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-beige-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-beige-1kg.yaml
@@ -1,0 +1,8 @@
+slug: elegoo-rapid-pla-plus-beige-1kg
+class: FFF
+material:
+  slug: elegoo-rapid-pla-plus-beige
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-beige-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-beige-1kg.yaml
@@ -1,5 +1,6 @@
 slug: elegoo-rapid-pla-plus-beige-1kg
 class: FFF
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 material:
   slug: elegoo-rapid-pla-plus-beige
 nominal_netto_full_weight: 1000

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-black-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-black-1kg.yaml
@@ -1,5 +1,6 @@
 slug: elegoo-rapid-pla-plus-black-1kg
 class: FFF
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 material:
   slug: elegoo-rapid-pla-plus-black
 nominal_netto_full_weight: 1000

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-black-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-black-1kg.yaml
@@ -1,0 +1,8 @@
+slug: elegoo-rapid-pla-plus-black-1kg
+class: FFF
+material:
+  slug: elegoo-rapid-pla-plus-black
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-blue-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-blue-1kg.yaml
@@ -1,5 +1,6 @@
 slug: elegoo-rapid-pla-plus-blue-1kg
 class: FFF
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 material:
   slug: elegoo-rapid-pla-plus-blue
 nominal_netto_full_weight: 1000

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-blue-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-blue-1kg.yaml
@@ -1,0 +1,8 @@
+slug: elegoo-rapid-pla-plus-blue-1kg
+class: FFF
+material:
+  slug: elegoo-rapid-pla-plus-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-brown-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-brown-1kg.yaml
@@ -1,0 +1,8 @@
+slug: elegoo-rapid-pla-plus-brown-1kg
+class: FFF
+material:
+  slug: elegoo-rapid-pla-plus-brown
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-brown-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-brown-1kg.yaml
@@ -1,5 +1,6 @@
 slug: elegoo-rapid-pla-plus-brown-1kg
 class: FFF
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 material:
   slug: elegoo-rapid-pla-plus-brown
 nominal_netto_full_weight: 1000

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-green-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-green-1kg.yaml
@@ -1,5 +1,6 @@
 slug: elegoo-rapid-pla-plus-green-1kg
 class: FFF
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 material:
   slug: elegoo-rapid-pla-plus-green
 nominal_netto_full_weight: 1000

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-green-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-green-1kg.yaml
@@ -1,0 +1,8 @@
+slug: elegoo-rapid-pla-plus-green-1kg
+class: FFF
+material:
+  slug: elegoo-rapid-pla-plus-green
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-grey-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-grey-1kg.yaml
@@ -1,0 +1,8 @@
+slug: elegoo-rapid-pla-plus-grey-1kg
+class: FFF
+material:
+  slug: elegoo-rapid-pla-plus-grey
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-grey-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-grey-1kg.yaml
@@ -1,5 +1,6 @@
 slug: elegoo-rapid-pla-plus-grey-1kg
 class: FFF
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 material:
   slug: elegoo-rapid-pla-plus-grey
 nominal_netto_full_weight: 1000

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-orange-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-orange-1kg.yaml
@@ -1,0 +1,8 @@
+slug: elegoo-rapid-pla-plus-orange-1kg
+class: FFF
+material:
+  slug: elegoo-rapid-pla-plus-orange
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-orange-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-orange-1kg.yaml
@@ -1,5 +1,6 @@
 slug: elegoo-rapid-pla-plus-orange-1kg
 class: FFF
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 material:
   slug: elegoo-rapid-pla-plus-orange
 nominal_netto_full_weight: 1000

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-red-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-red-1kg.yaml
@@ -1,5 +1,6 @@
 slug: elegoo-rapid-pla-plus-red-1kg
 class: FFF
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 material:
   slug: elegoo-rapid-pla-plus-red
 nominal_netto_full_weight: 1000

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-red-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-red-1kg.yaml
@@ -1,0 +1,8 @@
+slug: elegoo-rapid-pla-plus-red-1kg
+class: FFF
+material:
+  slug: elegoo-rapid-pla-plus-red
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-silver-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-silver-1kg.yaml
@@ -1,5 +1,6 @@
 slug: elegoo-rapid-pla-plus-silver-1kg
 class: FFF
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 material:
   slug: elegoo-rapid-pla-plus-silver
 nominal_netto_full_weight: 1000

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-silver-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-silver-1kg.yaml
@@ -1,0 +1,8 @@
+slug: elegoo-rapid-pla-plus-silver-1kg
+class: FFF
+material:
+  slug: elegoo-rapid-pla-plus-silver
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-white-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-white-1kg.yaml
@@ -1,0 +1,8 @@
+slug: elegoo-rapid-pla-plus-white-1kg
+class: FFF
+material:
+  slug: elegoo-rapid-pla-plus-white
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-white-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-white-1kg.yaml
@@ -1,5 +1,6 @@
 slug: elegoo-rapid-pla-plus-white-1kg
 class: FFF
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 material:
   slug: elegoo-rapid-pla-plus-white
 nominal_netto_full_weight: 1000

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-yellow-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-yellow-1kg.yaml
@@ -1,0 +1,8 @@
+slug: elegoo-rapid-pla-plus-yellow-1kg
+class: FFF
+material:
+  slug: elegoo-rapid-pla-plus-yellow
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-pla-plus-yellow-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-pla-plus-yellow-1kg.yaml
@@ -1,5 +1,6 @@
 slug: elegoo-rapid-pla-plus-yellow-1kg
 class: FFF
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 material:
   slug: elegoo-rapid-pla-plus-yellow
 nominal_netto_full_weight: 1000

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-beige.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-beige.yaml
@@ -6,7 +6,6 @@ name: RAPID PLA Plus Beige
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#dac7a0ff'
 tags:

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-beige.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-beige.yaml
@@ -6,11 +6,21 @@ name: RAPID PLA Plus Beige
 class: FFF
 type: PLA
 abbreviation: PLA
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#dac7a0ff'
 tags:
 - industrially_compostable
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-pla-plus-beige/c6810af6a910.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.23
+  min_print_temperature: 200
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-black.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-black.yaml
@@ -6,7 +6,6 @@ name: RAPID PLA Plus Black
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#000000ff'
 tags:

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-black.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-black.yaml
@@ -6,11 +6,21 @@ name: RAPID PLA Plus Black
 class: FFF
 type: PLA
 abbreviation: PLA
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#000000ff'
 tags:
 - industrially_compostable
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-pla-plus-black/fbf3ee6ce0c6.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.23
+  min_print_temperature: 200
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-blue.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-blue.yaml
@@ -6,11 +6,21 @@ name: RAPID PLA Plus Blue
 class: FFF
 type: PLA
 abbreviation: PLA
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#0e21aeff'
 tags:
 - industrially_compostable
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-pla-plus-blue/f7b1da3b53ab.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.23
+  min_print_temperature: 200
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-blue.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-blue.yaml
@@ -6,7 +6,6 @@ name: RAPID PLA Plus Blue
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#0e21aeff'
 tags:

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-brown.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-brown.yaml
@@ -6,11 +6,21 @@ name: RAPID PLA Plus Brown
 class: FFF
 type: PLA
 abbreviation: PLA
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#a45b27ff'
 tags:
 - industrially_compostable
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-pla-plus-brown/8dcd427d8d93.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.23
+  min_print_temperature: 200
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-brown.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-brown.yaml
@@ -6,7 +6,6 @@ name: RAPID PLA Plus Brown
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#a45b27ff'
 tags:

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-green.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-green.yaml
@@ -6,7 +6,6 @@ name: RAPID PLA Plus Green
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#4dff64ff'
 tags:

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-green.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-green.yaml
@@ -6,11 +6,21 @@ name: RAPID PLA Plus Green
 class: FFF
 type: PLA
 abbreviation: PLA
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#4dff64ff'
 tags:
 - industrially_compostable
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-pla-plus-green/c7be8dc7d100.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.23
+  min_print_temperature: 200
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-grey.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-grey.yaml
@@ -6,7 +6,6 @@ name: RAPID PLA Plus Grey
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#9f9f9fff'
 tags:

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-grey.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-grey.yaml
@@ -6,11 +6,21 @@ name: RAPID PLA Plus Grey
 class: FFF
 type: PLA
 abbreviation: PLA
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#9f9f9fff'
 tags:
 - industrially_compostable
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-pla-plus-grey/92b970e79a04.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.23
+  min_print_temperature: 200
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-orange.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-orange.yaml
@@ -6,7 +6,6 @@ name: RAPID PLA Plus Orange
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#ff8e24ff'
 tags:

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-orange.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-orange.yaml
@@ -6,11 +6,21 @@ name: RAPID PLA Plus Orange
 class: FFF
 type: PLA
 abbreviation: PLA
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#ff8e24ff'
 tags:
 - industrially_compostable
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-pla-plus-orange/a5dcf3fa1461.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.23
+  min_print_temperature: 200
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-red.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-red.yaml
@@ -6,7 +6,6 @@ name: RAPID PLA Plus Red
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#de1619ff'
 tags:

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-red.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-red.yaml
@@ -6,11 +6,21 @@ name: RAPID PLA Plus Red
 class: FFF
 type: PLA
 abbreviation: PLA
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#de1619ff'
 tags:
 - industrially_compostable
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-pla-plus-red/4e91b781ef85.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.23
+  min_print_temperature: 200
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-silver.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-silver.yaml
@@ -6,7 +6,6 @@ name: RAPID PLA Plus Silver
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#6f727eff'
 tags:

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-silver.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-silver.yaml
@@ -6,11 +6,21 @@ name: RAPID PLA Plus Silver
 class: FFF
 type: PLA
 abbreviation: PLA
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#6f727eff'
 tags:
 - industrially_compostable
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-pla-plus-silver/a75a97b529b2.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.23
+  min_print_temperature: 200
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-white.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-white.yaml
@@ -6,7 +6,6 @@ name: RAPID PLA Plus White
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#ffffffff'
 tags:

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-white.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-white.yaml
@@ -6,11 +6,21 @@ name: RAPID PLA Plus White
 class: FFF
 type: PLA
 abbreviation: PLA
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#ffffffff'
 tags:
 - industrially_compostable
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-pla-plus-white/3c60e9230973.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.23
+  min_print_temperature: 200
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-yellow.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-yellow.yaml
@@ -6,11 +6,21 @@ name: RAPID PLA Plus Yellow
 class: FFF
 type: PLA
 abbreviation: PLA
+url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#fbe200ff'
 tags:
 - industrially_compostable
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-pla-plus-yellow/f651779da72a.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.23
+  min_print_temperature: 200
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-pla-plus-yellow.yaml
+++ b/data/materials/elegoo/elegoo-rapid-pla-plus-yellow.yaml
@@ -6,7 +6,6 @@ name: RAPID PLA Plus Yellow
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg
 primary_color:
   color_rgba: '#fbe200ff'
 tags:


### PR DESCRIPTION
## Summary
Fills in the 11 ELEGOO RAPID PLA Plus materials with official specs, and adds the
cardboard spool container plus matching 1 kg packages.

### Materials (11) — `elegoo-rapid-pla-plus-*`
- Added `url` (official product page)
- Added `high_speed` tag (RAPID line, rated <600 mm/s, elevated melt index)
- Populated `properties` from ELEGOO's published spec sheet:
  density 1.23 g/cm³, nozzle 200–230 °C, bed 35–65 °C, drying 50 °C / 8 h, min nozzle 0.2 mm

### Container (1)
- `elegoo-cardboard-spool-1kg` — 1 kg cardboard spool: hole 54 mm, outer 200 mm,
  width 65 mm, empty weight 154 g

### Packages (11)
- `elegoo-rapid-pla-plus-<color>-1kg` — 1 kg / 1.75 mm, each linked to the cardboard spool

Source: https://us.elegoo.com/products/elegoo-rapid-pla-plus-filament-1-75mm-colored-1kg