### PR TITLE
Add Hatchbox Light Blue PLA, Forest Green PLA, Transparent White ABS …

### DIFF
--- a/data/material-containers/hatchbox-spool-1kg.yaml
+++ b/data/material-containers/hatchbox-spool-1kg.yaml
@@ -1,0 +1,7 @@
+uuid: 9f390ce7-4894-4565-bda4-8ef9f6c9b6d1
+slug: hatchbox-spool-1kg
+name: Hatchbox Spool 1kg
+class: FFF
+brand:
+  slug: hatchbox
+empty_weight: 245

--- a/data/material-packages/hatchbox/hatchbox-forest-green-pla-filament-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-forest-green-pla-filament-1kg.yaml
@@ -1,0 +1,11 @@
+uuid: 6ab0954f-0471-5957-a73a-f39a4ccb546b
+slug: hatchbox-forest-green-pla-filament-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-fgrn
+material:
+  slug: hatchbox-forest-green-pla-filament
+nominal_netto_full_weight: 1000
+gtin: 191314037735
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/hatchbox/hatchbox-light-blue-pla-filament-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-light-blue-pla-filament-1kg.yaml
@@ -1,0 +1,11 @@
+uuid: a643f1c6-2956-5a3f-9198-570c570e37c8
+slug: hatchbox-light-blue-pla-filament-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-285c
+material:
+  slug: hatchbox-light-blue-pla-filament
+nominal_netto_full_weight: 1000
+gtin: 849344041702
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/hatchbox/hatchbox-transparent-white-abs-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-transparent-white-abs-1kg.yaml
@@ -1,0 +1,9 @@
+slug: hatchbox-transparent-white-abs-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-abs-1kg1-75-twht
+material:
+  slug: hatchbox-transparent-white-abs
+nominal_netto_full_weight: 1000
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/materials/hatchbox/hatchbox-forest-green-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-forest-green-pla-filament.yaml
@@ -1,0 +1,15 @@
+uuid: 2bb27956-6896-51ae-9dc4-1805892004c9
+slug: hatchbox-forest-green-pla-filament
+brand:
+  slug: hatchbox
+name: Forest Green PLA Filament
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#0d4b0dff'
+photos:
+- url: https://www.hatchbox3d.com/cdn/shop/products/3D-PLA-1KG1.75-FGRN-Picture-1.jpg?v=1659720618&width=1800
+  type: package
+properties:
+  density: 1.27

--- a/data/materials/hatchbox/hatchbox-light-blue-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-light-blue-pla-filament.yaml
@@ -1,0 +1,15 @@
+uuid: 3b1273b9-242e-5965-8d8a-099bf0957eba
+slug: hatchbox-light-blue-pla-filament
+brand:
+  slug: hatchbox
+name: Light Blue PLA Filament
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#0e69aaff'
+photos:
+- url: https://www.hatchbox3d.com/cdn/shop/products/3DPLA-1kg1.75-285C-Picture-1.jpg?v=1648596994&width=1800
+  type: package
+properties:
+  density: 1.27

--- a/data/materials/hatchbox/hatchbox-transparent-white-abs.yaml
+++ b/data/materials/hatchbox/hatchbox-transparent-white-abs.yaml
@@ -1,0 +1,18 @@
+uuid: abaa51c9-1ad2-52e9-944a-58c7f743e33f
+slug: hatchbox-transparent-white-abs
+brand:
+  slug: hatchbox
+name: Transparent White ABS
+class: FFF
+type: ABS
+abbreviation: ABS
+primary_color:
+  color_rgba: '#ffffffff'
+tags:
+- translucent
+- filtration_recommended
+photos:
+- url: https://www.hatchbox3d.com/cdn/shop/products/3DABS-1KG1.75-TWHT-Picture-1_4f83a484-bba1-495d-b0d9-8fa86f0120f1.jpg?v=1648589755&width=1800
+  type: package
+properties:
+  density: 1.24


### PR DESCRIPTION
Adds three new Hatchbox materials, the Hatchbox 1 kg spool container, and a package for each.

### Materials
- Light Blue PLA Filament (`#0e69aa`, density 1.27)
- Forest Green PLA Filament (`#0d4b0d`, density 1.27)
- Transparent White ABS (`#ffffff`, density 1.24, tags: translucent, filtration_recommended)

### Container
- `hatchbox-spool-1kg` — 1 kg spool, empty weight 245 g

### Packages (1.75 mm, 1 kg, on the Hatchbox spool)
- Light Blue PLA — GTIN 849344041702
- Forest Green PLA — GTIN 191314037735
- Transparent White ABS — GTIN to be added