### PR TITLE
Add Amolen PLA Silk Basic Pumpkin Orange with 1kg spool and package

### DIFF
--- a/data/material-containers/amolen-spool-1kg.yaml
+++ b/data/material-containers/amolen-spool-1kg.yaml
@@ -1,0 +1,7 @@
+uuid: 5ae9f93f-148f-47a3-b816-7d493bd51cb7
+slug: amolen-spool-1kg
+name: Amolen Spool 1kg
+class: FFF
+brand:
+  slug: amolen
+empty_weight: 190

--- a/data/material-packages/amolen/amolen-pla-silk-basic-pumpkin-orange-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-pumpkin-orange-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-pumpkin-orange-1kg
+class: FFF
+url: https://www.amazon.com/dp/B0FL7T8S5X
+material:
+  slug: amolen-pla-silk-basic-pumpkin-orange
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/materials/amolen/amolen-pla-silk-basic-pumpkin-orange.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-pumpkin-orange.yaml
@@ -1,0 +1,22 @@
+uuid: 0d3ed614-a091-553b-abff-b67bc6b6d572
+slug: amolen-pla-silk-basic-pumpkin-orange
+brand:
+  slug: amolen
+name: PLA Silk Basic Pumpkin Orange
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#f26a1bff'
+tags:
+- silk
+- industrially_compostable
+photos:
+- url: https://m.media-amazon.com/images/I/71o0CqCjyQL._SL1500_.jpg
+  type: package
+properties:
+  density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 60


### PR DESCRIPTION
Adds the missing Amolen PLA Silk Basic "Pumpkin Orange" — an Amazon-exclusive color that
isn't listed on Amolen's own site — plus the first Amolen spool container and a package.

### Material
- `amolen-pla-silk-basic-pumpkin-orange` — PLA Silk Basic, print 210–240 °C, bed 30–60 °C
  (from the spool label), density 1.27, tags: silk
  Product photo from the listing.

### Container (first Amolen spool)
- `amolen-spool-1kg` — 1 kg plastic spool, empty weight 190 g.

### Package
- `amolen-pla-silk-basic-pumpkin-orange-1kg` — 1.75 mm / 1 kg, product URL on the package.

Notes: this color is Amazon-exclusive, so the package URL is the Amazon listing (no Amolen
product page exists) and no GTIN is published yet. 