### PR TITLE
Add ELEGOO PLA Translucent, Green, Hot Pink, and Matte Orange 

### DIFF
--- a/data/material-packages/elegoo/elegoo-pla-matte-orange-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-matte-orange-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-matte-orange-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3DF-PM0737
+url: https://us.elegoo.com/products/pla-matte-filament-1-75mm-colored-1kg?variant=51638576054453
+material:
+  slug: elegoo-pla-matte-orange
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-translucent-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-translucent-1kg.yaml
@@ -1,0 +1,9 @@
+slug: elegoo-pla-translucent-1kg
+class: FFF
+url: https://www.amazon.com/dp/B0DM1QTZKN
+material:
+  slug: elegoo-pla-translucent
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/materials/elegoo/elegoo-pla-green.yaml
+++ b/data/materials/elegoo/elegoo-pla-green.yaml
@@ -1,0 +1,23 @@
+uuid: 4f5694e7-b5f1-5eb2-80c4-13ea1937f1c5
+slug: elegoo-pla-green
+brand:
+  slug: elegoo
+name: PLA Green
+class: FFF
+type: PLA
+abbreviation: PLA
+brand_specific_id: SPUS-EL-PLA-N017
+url: https://us.elegoo.com/products/pla-basic-filament-1-75mm-colored-1kg?variant=51248966664373
+primary_color:
+  color_rgba: '#02cc6cff'
+photos:
+- url: https://m.media-amazon.com/images/I/81IpGKRM3mL._AC_SL1500_.jpg
+  type: unspecified
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 360

--- a/data/materials/elegoo/elegoo-pla-hot-pink.yaml
+++ b/data/materials/elegoo/elegoo-pla-hot-pink.yaml
@@ -1,0 +1,23 @@
+uuid: 566208d2-90b6-5662-8fcb-685346d075e6
+slug: elegoo-pla-hot-pink
+brand:
+  slug: elegoo
+name: PLA Hot Pink
+class: FFF
+type: PLA
+abbreviation: PLA
+brand_specific_id: SPUS-EL-PLA-N007
+url: https://us.elegoo.com/products/pla-basic-filament-1-75mm-colored-1kg?variant=51248966336693
+primary_color:
+  color_rgba: '#fa7291ff'
+photos:
+- url: https://m.media-amazon.com/images/I/81JcYqJTmSL._AC_SL1500_.jpg
+  type: unspecified
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 360

--- a/data/materials/elegoo/elegoo-pla-matte-orange.yaml
+++ b/data/materials/elegoo/elegoo-pla-matte-orange.yaml
@@ -1,0 +1,21 @@
+uuid: 5dac2b85-820a-5138-87d3-ac3e30a98455
+slug: elegoo-pla-matte-orange
+brand:
+  slug: elegoo
+name: PLA Matte Orange
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#ed944dff'
+tags:
+- matte
+photos:
+- url: https://us.elegoo.com/cdn/shop/files/MATTE.jpg?crop=center&v=1756886961&width=1220
+  type: unspecified
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65

--- a/data/materials/elegoo/elegoo-pla-translucent.yaml
+++ b/data/materials/elegoo/elegoo-pla-translucent.yaml
@@ -1,0 +1,20 @@
+uuid: f58efc21-d53c-5646-8082-4fd5bc36f5a6
+slug: elegoo-pla-translucent
+brand:
+  slug: elegoo
+name: PLA Translucent
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#9da6b8ff'
+tags:
+- translucent
+photos:
+- url: https://m.media-amazon.com/images/I/71OTwk0HekL._AC_SL1500_.jpg
+  type: package
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65


### PR DESCRIPTION
Adds four missing ELEGOO PLA colors (PLA Basic + Matte lines), with packages where applicable.

Materials (specs from spool labels / ELEGOO product data):
- PLA Translucent (#9da6b8) — print 190–230, bed 35–65
- PLA Green (#02cc6c) — print 190–230, bed 35–65, density 1.24, drying 55 °C/6 h
- PLA Hot Pink (#fa7291) — same props as Green
- PLA Matte Orange (#ed944d) — print 190–230, bed 35–65, density 1.26, tag: matte

Packages:
- Translucent & Matte Orange ship on the cardboard spool → 1 kg packages on
  elegoo-cardboard-spool-1kg, with official ELEGOO product URLs + SKUs.
- Green & Hot Pink are refills (no spool) → material only; refill URL + SKU on the material.