### PR TITLE
Add TTYT3D brand and PLA Silk Rainbow Multicolor with plastic spool c…

### DIFF
--- a/data/brands/ttyt3d.yaml
+++ b/data/brands/ttyt3d.yaml
@@ -1,0 +1,5 @@
+uuid: 00719ea8-d5cf-5762-b2bd-307b88b7b75e
+slug: ttyt3d
+name: TTYT3D
+countries_of_origin:
+  - CN

--- a/data/material-containers/ttyt3d-plastic-spool-1kg.yaml
+++ b/data/material-containers/ttyt3d-plastic-spool-1kg.yaml
@@ -1,0 +1,7 @@
+uuid: 3040d274-67e3-48e7-8f61-92f2bcf8363d
+slug: ttyt3d-plastic-spool-1kg
+name: TTYT3D Plastic Spool 1kg
+class: FFF
+brand:
+  slug: ttyt3d
+empty_weight: 190

--- a/data/material-packages/ttyt3d/ttyt3d-pla-silk-rainbow-multicolor-1kg.yaml
+++ b/data/material-packages/ttyt3d/ttyt3d-pla-silk-rainbow-multicolor-1kg.yaml
@@ -1,0 +1,9 @@
+slug: ttyt3d-pla-silk-rainbow-multicolor-1kg
+class: FFF
+url: https://www.amazon.com/dp/B07VJ2RHKF
+material:
+  slug: ttyt3d-pla-silk-rainbow-multicolor
+nominal_netto_full_weight: 1000
+container:
+  slug: ttyt3d-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/materials/ttyt3d/ttyt3d-pla-silk-rainbow-multicolor.yaml
+++ b/data/materials/ttyt3d/ttyt3d-pla-silk-rainbow-multicolor.yaml
@@ -1,0 +1,25 @@
+uuid: 58658497-b739-5a18-a6bd-e28c60cda640
+slug: ttyt3d-pla-silk-rainbow-multicolor
+brand:
+  slug: ttyt3d
+name: PLA Silk Rainbow Multicolor
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#ff0000ff'
+- color_rgba: '#ffff00ff'
+- color_rgba: '#00ff00ff'
+- color_rgba: '#0000ffff'
+tags:
+- silk
+- gradual_color_change
+properties:
+  density: 1.24
+  min_print_temperature: 205
+  max_print_temperature: 230
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+photos:
+- url: https://m.media-amazon.com/images/I/71PD9aSaeaL._AC_SL1500_.jpg
+  type: unspecified


### PR DESCRIPTION
Adds the TTYT3D brand (CN) and its PLA Silk Rainbow Multicolor (1.75mm, 1kg): material, plastic spool container, and 1kg package. Specs from the product/Amazon listing. Validated with make validate.