### PR TITLE
Add Inslogic brand and High-Speed Marble PLA Chestnut Brown with reus…

### DIFF
--- a/data/brands/inslogic.yaml
+++ b/data/brands/inslogic.yaml
@@ -1,0 +1,5 @@
+uuid: eab2743d-d6cf-57e8-8521-b55e072e1672
+slug: inslogic
+name: Inslogic
+countries_of_origin:
+  - CN

--- a/data/material-containers/inslogic-reusable-spool-1kg.yaml
+++ b/data/material-containers/inslogic-reusable-spool-1kg.yaml
@@ -1,0 +1,10 @@
+uuid: df06e496-c82d-40fd-8c35-a384eb87551f
+slug: inslogic-reusable-spool-1kg
+name: Inslogic Reusable Spool 1kg
+class: FFF
+brand:
+  slug: inslogic
+hole_diameter: 55
+outer_diameter: 200
+width: 67
+empty_weight: 232

--- a/data/material-packages/inslogic/inslogic-high-speed-marble-pla-chestnut-brown-1kg.yaml
+++ b/data/material-packages/inslogic/inslogic-high-speed-marble-pla-chestnut-brown-1kg.yaml
@@ -1,0 +1,9 @@
+slug: inslogic-high-speed-marble-pla-chestnut-brown-1kg
+class: FFF
+url: https://www.inslogic3d.com/products/inslogic-high-speed-marble-pla
+material:
+  slug: inslogic-high-speed-marble-pla-chestnut-brown
+nominal_netto_full_weight: 1000
+container:
+  slug: inslogic-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/materials/inslogic/inslogic-high-speed-marble-pla-chestnut-brown.yaml
+++ b/data/materials/inslogic/inslogic-high-speed-marble-pla-chestnut-brown.yaml
@@ -1,0 +1,26 @@
+uuid: a6ab7094-c019-5ce8-b103-7f50cbe84a39
+slug: inslogic-high-speed-marble-pla-chestnut-brown
+brand:
+  slug: inslogic
+name: High-Speed Marble PLA Chestnut Brown
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#ffe2c2ff'
+tags:
+- high_speed
+- imitates_marble
+properties:
+  density: 1.25
+  hardness_shore_d: 82
+  min_print_temperature: 190
+  max_print_temperature: 260
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 240
+  min_nozzle_diameter: 400
+photos:
+- url: https://m.media-amazon.com/images/I/71BmocGSJaL._AC_SL1500_.jpg
+  type: unspecified


### PR DESCRIPTION
Adds the Inslogic brand (CN) and its High-Speed Marble PLA Chestnut Brown (1.75mm, 1kg): material, reusable spool container, and 1kg package. Specs from the official product page / box. Validated with make validate.