### PR TITLE
Add print, bed, drying, and nozzle properties to Fiberthree F3 PA-CF Pro

### DIFF
--- a/data/materials/fiberthree/fiberthree-f3-pa-cf-pro.yaml
+++ b/data/materials/fiberthree/fiberthree-f3-pa-cf-pro.yaml
@@ -14,3 +14,10 @@ tags:
 - abrasive
 properties:
   density: 1.25
+  min_print_temperature: 270
+  max_print_temperature: 285
+  min_bed_temperature: 60
+  max_bed_temperature: 80
+  drying_temperature: 80
+  drying_time: 480
+  min_nozzle_diameter: 400


### PR DESCRIPTION
Fills in print/bed/drying/nozzle properties on the existing Fiberthree F3 PA-CF Pro material (previously density-only). Values from the Fiberthree spec PDF, product box, and Prusa listing. Validated with make validate.