### PR TITLE
Clean up ELEGOO PLA Matte line: correct colors, add specs, packages, …

### DIFF
--- a/data/material-packages/elegoo/elegoo-pla-matte-beige-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-matte-beige-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-matte-beige-1kg
+class: FFF
+brand_specific_id: SPUS-EL-MAT-111
+url: https://us.elegoo.com/products/pla-matte-filament-1-75mm-colored-1kg?variant=43734199992501
+material:
+  slug: elegoo-pla-matte-beige
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-matte-black-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-matte-black-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-matte-black-1kg
+class: FFF
+brand_specific_id: SPUS-EL-MAT-101
+url: https://us.elegoo.com/products/pla-matte-filament-1-75mm-colored-1kg?variant=43734199664821
+material:
+  slug: elegoo-pla-matte-black
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-matte-earth-brown-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-matte-earth-brown-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-matte-earth-brown-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3DF-PM0736
+url: https://us.elegoo.com/products/pla-matte-filament-1-75mm-colored-1kg?variant=51638576021685
+material:
+  slug: elegoo-pla-matte-earth-brown
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-matte-ice-blue-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-matte-ice-blue-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-matte-ice-blue-1kg
+class: FFF
+brand_specific_id: SPUS-EL-MAT-110
+url: https://us.elegoo.com/products/pla-matte-filament-1-75mm-colored-1kg?variant=43734199959733
+material:
+  slug: elegoo-pla-matte-ice-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-matte-lavender-purple-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-matte-lavender-purple-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-matte-lavender-purple-1kg
+class: FFF
+brand_specific_id: SPUS-EL-MAT-108
+url: https://us.elegoo.com/products/pla-matte-filament-1-75mm-colored-1kg?variant=43734199894197
+material:
+  slug: elegoo-pla-matte-lavender-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-matte-mint-green-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-matte-mint-green-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-matte-mint-green-1kg
+class: FFF
+brand_specific_id: SPUS-EL-MAT-112
+url: https://us.elegoo.com/products/pla-matte-filament-1-75mm-colored-1kg?variant=43734200025269
+material:
+  slug: elegoo-pla-matte-mint-green
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-matte-navy-blue-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-matte-navy-blue-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-matte-navy-blue-1kg
+class: FFF
+brand_specific_id: SPUS-EL-MAT-104
+url: https://us.elegoo.com/products/pla-matte-filament-1-75mm-colored-1kg?variant=43734199763125
+material:
+  slug: elegoo-pla-matte-navy-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-matte-ruby-red-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-matte-ruby-red-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-matte-ruby-red-1kg
+class: FFF
+brand_specific_id: SPUS-EL-MAT-103
+url: https://us.elegoo.com/products/pla-matte-filament-1-75mm-colored-1kg?variant=43734199730357
+material:
+  slug: elegoo-pla-matte-ruby-red
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-matte-sakura-pink-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-matte-sakura-pink-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-matte-sakura-pink-1kg
+class: FFF
+brand_specific_id: SPUS-EL-MAT-109
+url: https://us.elegoo.com/products/pla-matte-filament-1-75mm-colored-1kg?variant=43734199926965
+material:
+  slug: elegoo-pla-matte-sakura-pink
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-matte-slate-grey-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-matte-slate-grey-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-matte-slate-grey-1kg
+class: FFF
+brand_specific_id: SPUS-EL-MAT-107
+url: https://us.elegoo.com/products/pla-matte-filament-1-75mm-colored-1kg?variant=43734199861429
+material:
+  slug: elegoo-pla-matte-slate-grey
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-matte-sunshine-yellow-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-matte-sunshine-yellow-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-matte-sunshine-yellow-1kg
+class: FFF
+brand_specific_id: SPUS-EL-MAT-106
+url: https://us.elegoo.com/products/pla-matte-filament-1-75mm-colored-1kg?variant=43734199828661
+material:
+  slug: elegoo-pla-matte-sunshine-yellow
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-matte-teal-green-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-matte-teal-green-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-matte-teal-green-1kg
+class: FFF
+brand_specific_id: SPUS-EL-MAT-105
+url: https://us.elegoo.com/products/pla-matte-filament-1-75mm-colored-1kg?variant=43734199795893
+material:
+  slug: elegoo-pla-matte-teal-green
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-matte-white-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-matte-white-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-matte-white-1kg
+class: FFF
+brand_specific_id: SPUS-EL-MAT-102
+url: https://us.elegoo.com/products/pla-matte-filament-1-75mm-colored-1kg?variant=43734199697589
+material:
+  slug: elegoo-pla-matte-white
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/materials/elegoo/elegoo-pla-matte-beige.yaml
+++ b/data/materials/elegoo/elegoo-pla-matte-beige.yaml
@@ -7,11 +7,17 @@ class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#e6d1bdff'
+  color_rgba: '#efd8beff'
 tags:
 - matte
-- industrially_compostable
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-matte-beige/80480574cb0b.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480

--- a/data/materials/elegoo/elegoo-pla-matte-black.yaml
+++ b/data/materials/elegoo/elegoo-pla-matte-black.yaml
@@ -7,11 +7,17 @@ class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#000000ff'
+  color_rgba: '#090909ff'
 tags:
 - matte
-- industrially_compostable
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-matte-black/9cd54067a40d.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480

--- a/data/materials/elegoo/elegoo-pla-matte-earth-brown.yaml
+++ b/data/materials/elegoo/elegoo-pla-matte-earth-brown.yaml
@@ -1,17 +1,17 @@
-uuid: 74876977-f04c-5e11-a668-252792eeead5
-slug: elegoo-pla-matte-navy-blue
+uuid: 1053b2ea-0892-557f-9f22-528a17709637
+slug: elegoo-pla-matte-earth-brown
 brand:
   slug: elegoo
-name: PLA Matte Navy Blue
+name: PLA Matte Earth Brown
 class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#142538ff'
+  color_rgba: '#9a6948ff'
 tags:
 - matte
 photos:
-- url: https://files.openprinttag.org/elegoo/elegoo-pla-matte-navy-blue/7cf6d02c401b.png
+- url: https://us.elegoo.com/cdn/shop/files/MATTE_3b93d9e5-2ef0-4e66-9106-a92eae472ef5.jpg?v=1756886961
   type: unspecified
 properties:
   density: 1.26

--- a/data/materials/elegoo/elegoo-pla-matte-ice-blue.yaml
+++ b/data/materials/elegoo/elegoo-pla-matte-ice-blue.yaml
@@ -7,11 +7,17 @@ class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#8ed9f9ff'
+  color_rgba: '#b4f5feff'
 tags:
 - matte
-- industrially_compostable
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-matte-ice-blue/e016e23d7d49.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480

--- a/data/materials/elegoo/elegoo-pla-matte-lavender-purple.yaml
+++ b/data/materials/elegoo/elegoo-pla-matte-lavender-purple.yaml
@@ -7,11 +7,17 @@ class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#ae96d4ff'
+  color_rgba: '#b091efff'
 tags:
 - matte
-- industrially_compostable
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-matte-lavender-purple/ee5eeb89577b.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480

--- a/data/materials/elegoo/elegoo-pla-matte-mint-green.yaml
+++ b/data/materials/elegoo/elegoo-pla-matte-mint-green.yaml
@@ -1,17 +1,17 @@
-uuid: 74876977-f04c-5e11-a668-252792eeead5
-slug: elegoo-pla-matte-navy-blue
+uuid: a65adcd6-34ba-5d9f-80f5-47ab3bfdeea2
+slug: elegoo-pla-matte-mint-green
 brand:
   slug: elegoo
-name: PLA Matte Navy Blue
+name: PLA Matte Mint Green
 class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#142538ff'
+  color_rgba: '#98ff98ff'
 tags:
 - matte
 photos:
-- url: https://files.openprinttag.org/elegoo/elegoo-pla-matte-navy-blue/7cf6d02c401b.png
+- url: https://us.elegoo.com/cdn/shop/products/PLAMATTE1KGMintGreen_2.jpg?v=1736417312
   type: unspecified
 properties:
   density: 1.26

--- a/data/materials/elegoo/elegoo-pla-matte-ruby-red.yaml
+++ b/data/materials/elegoo/elegoo-pla-matte-ruby-red.yaml
@@ -1,17 +1,17 @@
-uuid: 74876977-f04c-5e11-a668-252792eeead5
-slug: elegoo-pla-matte-navy-blue
+uuid: 5502ab7a-b4fa-5be3-8150-31b74de8865e
+slug: elegoo-pla-matte-ruby-red
 brand:
   slug: elegoo
-name: PLA Matte Navy Blue
+name: PLA Matte Ruby Red
 class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#142538ff'
+  color_rgba: '#bb2c2eff'
 tags:
 - matte
 photos:
-- url: https://files.openprinttag.org/elegoo/elegoo-pla-matte-navy-blue/7cf6d02c401b.png
+- url: https://us.elegoo.com/cdn/shop/files/PLA_MATTE_1KG.jpg?v=1757934640
   type: unspecified
 properties:
   density: 1.26

--- a/data/materials/elegoo/elegoo-pla-matte-sakura-pink.yaml
+++ b/data/materials/elegoo/elegoo-pla-matte-sakura-pink.yaml
@@ -7,11 +7,17 @@ class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#ffbadeff'
+  color_rgba: '#ffc2f4ff'
 tags:
 - matte
-- industrially_compostable
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-matte-sakura-pink/1b5afd1ec887.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480

--- a/data/materials/elegoo/elegoo-pla-matte-slate-grey.yaml
+++ b/data/materials/elegoo/elegoo-pla-matte-slate-grey.yaml
@@ -1,17 +1,23 @@
-uuid: 3f4ad005-4a60-5a36-bb58-2e8cb8cd1ac7
+uuid: 030e1083-dce4-5fc9-9e7a-52438adb21ed
 slug: elegoo-pla-matte-slate-grey
 brand:
   slug: elegoo
-name: PLA MATTE Slate Grey
+name: PLA Matte Slate Grey
 class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#b2b8b8ff'
+  color_rgba: '#969799ff'
 tags:
 - matte
-- industrially_compostable
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-matte-slate-grey/af8e8a51f92b.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480

--- a/data/materials/elegoo/elegoo-pla-matte-sunshine-yellow.yaml
+++ b/data/materials/elegoo/elegoo-pla-matte-sunshine-yellow.yaml
@@ -7,11 +7,17 @@ class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#ffd342ff'
+  color_rgba: '#f9e069ff'
 tags:
 - matte
-- industrially_compostable
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-matte-sunshine-yellow/c818ba318e38.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480

--- a/data/materials/elegoo/elegoo-pla-matte-teal-green.yaml
+++ b/data/materials/elegoo/elegoo-pla-matte-teal-green.yaml
@@ -7,11 +7,17 @@ class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#9ae0ddff'
+  color_rgba: '#85e2ddff'
 tags:
 - matte
-- industrially_compostable
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-matte-teal-green/a5a4d3d87b0d.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480

--- a/data/materials/elegoo/elegoo-pla-matte-white.yaml
+++ b/data/materials/elegoo/elegoo-pla-matte-white.yaml
@@ -10,8 +10,14 @@ primary_color:
   color_rgba: '#ffffffff'
 tags:
 - matte
-- industrially_compostable
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-matte-white/2b15dd9a22a5.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480


### PR DESCRIPTION
…and missing colors

Materials (updated):
- Correct primary colors (Navy Blue, Matte Black, Sunshine Yellow, Slate Grey, Lavender Purple, Sakura Pink, Ice Blue, Beige, Teal Green)
- Add full property block (density, print/bed temps, drying) from ELEGOO datasheet
- Remove industrially_compostable tag (compostable but not certified)
- Fix Slate Grey name capitalization (PLA MATTE -> PLA Matte), UUID re-derived

Materials (new): Ruby Red, Earth Brown, Mint Green

Packages (new): 1kg spool packages for all 13 colors lacking one