### PR TITLE
Updates for Amolen PLA Silk S-Series

### DIFF
--- a/data/material-containers/amolen-spool-1kg.yaml
+++ b/data/material-containers/amolen-spool-1kg.yaml
@@ -4,4 +4,8 @@ name: Amolen Spool 1kg
 class: FFF
 brand:
   slug: amolen
+hole_diameter: 60
+inner_diameter: 80
+outer_diameter: 200
+width: 60
 empty_weight: 190

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-amber-sea-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-amber-sea-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-amber-sea-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=41817241845783
+material:
+  slug: amolen-pla-silk-s-series-amber-sea
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-berry-pop-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-berry-pop-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-berry-pop-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=41817241944087
+material:
+  slug: amolen-pla-silk-s-series-berry-pop
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-black-blue-purple-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-black-blue-purple-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-black-blue-purple-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=40819669532695
+material:
+  slug: amolen-pla-silk-s-series-black-blue-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-black-pink-white-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-black-pink-white-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-black-pink-white-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=40819068895255
+material:
+  slug: amolen-pla-silk-s-series-black-pink-white
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-black-red-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-black-red-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-black-red-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=40833693319191
+material:
+  slug: amolen-pla-silk-s-series-black-red
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-black-red-yellow-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-black-red-yellow-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-black-red-yellow-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=40767941345303
+material:
+  slug: amolen-pla-silk-s-series-black-red-yellow
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-black-turquoise-fuchsia-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-black-turquoise-fuchsia-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-black-turquoise-fuchsia-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=41647021654039
+material:
+  slug: amolen-pla-silk-s-series-black-turquoise-fuchsia
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-blue-green-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-blue-green-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-blue-green-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=40819669630999
+material:
+  slug: amolen-pla-silk-s-series-blue-green
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-blue-pink-green-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-blue-pink-green-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-blue-pink-green-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=41734949142551
+material:
+  slug: amolen-pla-silk-s-series-blue-pink-green
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-blue-pink-white-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-blue-pink-white-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-blue-pink-white-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=41788950020119
+material:
+  slug: amolen-pla-silk-s-series-blue-pink-white
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-blue-red-yellow-green-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-blue-red-yellow-green-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-blue-red-yellow-green-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=40744162066455
+material:
+  slug: amolen-pla-silk-s-series-blue-red-yellow-green
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-gold-purple-red-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-gold-purple-red-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-gold-purple-red-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=41866778574871
+material:
+  slug: amolen-pla-silk-s-series-gold-purple-red
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-green-fuchsia-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-green-fuchsia-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-green-fuchsia-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=41560613617687
+material:
+  slug: amolen-pla-silk-s-series-green-fuchsia
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-nebula-ribbon-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-nebula-ribbon-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-nebula-ribbon-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=41872301064215
+material:
+  slug: amolen-pla-silk-s-series-nebula-ribbon
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-red-white-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-red-white-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-red-white-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=41788949921815
+material:
+  slug: amolen-pla-silk-s-series-red-white
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-s-series-twilight-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-s-series-twilight-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-s-series-twilight-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-s-series?variant=41755153137687
+material:
+  slug: amolen-pla-silk-s-series-twilight
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/materials/amolen/amolen-pla-silk-s-series-amber-sea.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-amber-sea.yaml
@@ -15,5 +15,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01304.jpg
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-berry-pop.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-berry-pop.yaml
@@ -15,5 +15,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01292.jpg
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-black-blue-purple.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-black-blue-purple.yaml
@@ -15,5 +15,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01271.jpg
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-black-pink-white.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-black-pink-white.yaml
@@ -15,5 +15,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01309.jpg
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-black-red-yellow.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-black-red-yellow.yaml
@@ -15,5 +15,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01264.jpg
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-black-red.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-black-red.yaml
@@ -14,5 +14,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01282.jpg
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-black-turquoise-fuchsia.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-black-turquoise-fuchsia.yaml
@@ -15,5 +15,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/81vYyJtnkcL._AC_SL1500.jpg
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-blue-green.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-blue-green.yaml
@@ -17,3 +17,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-blue-pink-green.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-blue-pink-green.yaml
@@ -15,5 +15,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01277.jpg
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-blue-pink-white.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-blue-pink-white.yaml
@@ -15,5 +15,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01333.jpg
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-blue-red-yellow-green.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-blue-red-yellow-green.yaml
@@ -15,5 +15,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/2_d779ea61-c924-4eff-8ebc-e256a95547f1.png
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-gold-purple-red.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-gold-purple-red.yaml
@@ -15,5 +15,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/1_a23113c6-62d3-4189-b659-3002ed386bd9.jpg
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-green-fuchsia.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-green-fuchsia.yaml
@@ -14,5 +14,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01324.jpg
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-nebula-ribbon.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-nebula-ribbon.yaml
@@ -15,5 +15,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01345.jpg
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-red-white.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-red-white.yaml
@@ -14,5 +14,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01349.jpg
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-s-series-twilight.yaml
+++ b/data/materials/amolen/amolen-pla-silk-s-series-twilight.yaml
@@ -15,5 +15,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01340.jpg
+  type: unspecified
 properties:
   density: 1.29
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480


### PR DESCRIPTION
Fills out the Amolen PLA Silk S-Series line with print specifications, per-color
photos, and 1kg packages, and adds physical dimensions to the Amolen spool.

### Materials (16)
- Added print/bed temperatures and drying settings from Amolen's official spec:
  nozzle 210–240 °C, bed 30–65 °C, drying 55 °C for 480 min.
- Density (1.29) and existing colors/tags left unchanged.
- Added per-color product photos to 15 of 16 colors (Blue Green has no
  manufacturer swatch available yet).

### Packages (16, new)
- 1kg packages linking each color to the `amolen-spool-1kg` container,
  1.75 mm filament. GTIN-less for now.

### Container
- Added physical dimensions to `amolen-spool-1kg`: hole 60 mm, inner 80 mm,
  outer 200 mm, width 60 mm (empty weight 190 g unchanged).