### PR TITLE
Updates for Amolen PLA Silk Shiny Gradient

### DIFF
--- a/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-azure-blue-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-azure-blue-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-shiny-gradient-azure-blue-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-shiny?variant=40532768948247
+material:
+  slug: amolen-pla-silk-shiny-gradient-azure-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-black-shiny-blue-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-black-shiny-blue-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-shiny-gradient-black-shiny-blue-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-shiny?variant=40609097383959
+material:
+  slug: amolen-pla-silk-shiny-gradient-black-shiny-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-black-shiny-fuchsia-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-black-shiny-fuchsia-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-shiny-gradient-black-shiny-fuchsia-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-shiny?variant=40532771438615
+material:
+  slug: amolen-pla-silk-shiny-gradient-black-shiny-fuchsia
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-black-shiny-green-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-black-shiny-green-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-shiny-gradient-black-shiny-green-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-shiny?variant=40532765704215
+material:
+  slug: amolen-pla-silk-shiny-gradient-black-shiny-green
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-black-shiny-purple-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-black-shiny-purple-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-shiny-gradient-black-shiny-purple-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-shiny?variant=40609094139927
+material:
+  slug: amolen-pla-silk-shiny-gradient-black-shiny-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-black-shiny-red-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-black-shiny-red-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-shiny-gradient-black-shiny-red-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-shiny?variant=40721642946583
+material:
+  slug: amolen-pla-silk-shiny-gradient-black-shiny-red
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-black-shiny-red-gold-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-black-shiny-red-gold-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-shiny-gradient-black-shiny-red-gold-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-shiny?variant=40532764131351
+material:
+  slug: amolen-pla-silk-shiny-gradient-black-shiny-red-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-blue-green-purple-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-blue-green-purple-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-shiny-gradient-blue-green-purple-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-shiny?variant=42762436444183
+material:
+  slug: amolen-pla-silk-shiny-gradient-blue-green-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-blue-purple-shiny-red-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-blue-purple-shiny-red-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-shiny-gradient-blue-purple-shiny-red-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-shiny?variant=40532771930135
+material:
+  slug: amolen-pla-silk-shiny-gradient-blue-purple-shiny-red
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-gold-shiny-purple-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-gold-shiny-purple-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-shiny-gradient-gold-shiny-purple-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-shiny?variant=39259058864151
+material:
+  slug: amolen-pla-silk-shiny-gradient-gold-shiny-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-gold-shiny-red-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-gold-shiny-red-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-shiny-gradient-gold-shiny-red-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-shiny?variant=39259058798615
+material:
+  slug: amolen-pla-silk-shiny-gradient-gold-shiny-red
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-silver-shiny-blue-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-shiny-gradient-silver-shiny-blue-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-shiny-gradient-silver-shiny-blue-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-shiny?variant=39259058831383
+material:
+  slug: amolen-pla-silk-shiny-gradient-silver-shiny-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/materials/amolen/amolen-pla-silk-shiny-gradient-azure-blue.yaml
+++ b/data/materials/amolen/amolen-pla-silk-shiny-gradient-azure-blue.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Shiny Gradient Azure Blue
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-shiny?variant=40532768948247
+url: https://www.amolen.com/products/pla-silk-shiny
 secondary_colors:
 - color_rgba: '#a5eeeeff'
 - color_rgba: '#4921c1ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/Silk_Gradient_Azure_Blue.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-shiny-gradient-black-shiny-blue.yaml
+++ b/data/materials/amolen/amolen-pla-silk-shiny-gradient-black-shiny-blue.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Shiny Gradient Black & Shiny Blue
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-shiny?variant=40609097383959
+url: https://www.amolen.com/products/pla-silk-shiny
 secondary_colors:
 - color_rgba: '#000000ff'
 - color_rgba: '#485cc7ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01913.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-shiny-gradient-black-shiny-fuchsia.yaml
+++ b/data/materials/amolen/amolen-pla-silk-shiny-gradient-black-shiny-fuchsia.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Shiny Gradient Black & Shiny Fuchsia
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-shiny?variant=40532771438615
+url: https://www.amolen.com/products/pla-silk-shiny
 secondary_colors:
 - color_rgba: '#000000ff'
 - color_rgba: '#d200a5ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01904.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-shiny-gradient-black-shiny-green.yaml
+++ b/data/materials/amolen/amolen-pla-silk-shiny-gradient-black-shiny-green.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Shiny Gradient Black & Shiny Green
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-shiny?variant=40532765704215
+url: https://www.amolen.com/products/pla-silk-shiny
 secondary_colors:
 - color_rgba: '#000000ff'
 - color_rgba: '#217165ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01909.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-shiny-gradient-black-shiny-purple.yaml
+++ b/data/materials/amolen/amolen-pla-silk-shiny-gradient-black-shiny-purple.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Shiny Gradient Black & Shiny Purple
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-shiny?variant=40609094139927
+url: https://www.amolen.com/products/pla-silk-shiny
 secondary_colors:
 - color_rgba: '#000000ff'
 - color_rgba: '#9d00b1ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/products/817vc1pIRbL._SL1500.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-shiny-gradient-black-shiny-red-gold.yaml
+++ b/data/materials/amolen/amolen-pla-silk-shiny-gradient-black-shiny-red-gold.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Shiny Gradient Black & Shiny Red Gold
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-shiny?variant=40532764131351
+url: https://www.amolen.com/products/pla-silk-shiny
 secondary_colors:
 - color_rgba: '#000000ff'
 - color_rgba: '#98282fff'
@@ -15,5 +15,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC00262.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-shiny-gradient-black-shiny-red.yaml
+++ b/data/materials/amolen/amolen-pla-silk-shiny-gradient-black-shiny-red.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Shiny Gradient Black & Shiny Red
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-shiny?variant=40721642946583
+url: https://www.amolen.com/products/pla-silk-shiny
 secondary_colors:
 - color_rgba: '#000000ff'
 - color_rgba: '#ad0028ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01909_554cecf2-ade7-4426-bebf-93676633bb37.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-shiny-gradient-blue-green-purple.yaml
+++ b/data/materials/amolen/amolen-pla-silk-shiny-gradient-blue-green-purple.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Shiny Gradient Blue Green Purple
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-shiny?variant=42762436444183
+url: https://www.amolen.com/products/pla-silk-shiny
 secondary_colors:
 - color_rgba: '#00a594ff'
 - color_rgba: '#6802bcff'
@@ -15,5 +15,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01918.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-shiny-gradient-blue-purple-shiny-red.yaml
+++ b/data/materials/amolen/amolen-pla-silk-shiny-gradient-blue-purple-shiny-red.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Shiny Gradient Blue Purple & Shiny Red
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-shiny?variant=40532771930135
+url: https://www.amolen.com/products/pla-silk-shiny
 secondary_colors:
 - color_rgba: '#b7293eff'
 - color_rgba: '#1b41a2ff'
@@ -15,5 +15,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC00044.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-shiny-gradient-gold-shiny-purple.yaml
+++ b/data/materials/amolen/amolen-pla-silk-shiny-gradient-gold-shiny-purple.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Shiny Gradient Gold & Shiny Purple
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-shiny?variant=39259058864151
+url: https://www.amolen.com/products/pla-silk-shiny
 secondary_colors:
 - color_rgba: '#f6c500ff'
 - color_rgba: '#804996ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/81_GmndTF4L.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-shiny-gradient-gold-shiny-red.yaml
+++ b/data/materials/amolen/amolen-pla-silk-shiny-gradient-gold-shiny-red.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Shiny Gradient Gold & Shiny Red
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-shiny?variant=39259058798615
+url: https://www.amolen.com/products/pla-silk-shiny
 secondary_colors:
 - color_rgba: '#c00000ff'
 - color_rgba: '#f6c500ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC00044_0c5ad09f-55c0-4c27-a0d2-041adcc5db06.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-shiny-gradient-silver-shiny-blue.yaml
+++ b/data/materials/amolen/amolen-pla-silk-shiny-gradient-silver-shiny-blue.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Shiny Gradient Silver & Shiny Blue
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-shiny?variant=39259058831383
+url: https://www.amolen.com/products/pla-silk-shiny
 secondary_colors:
 - color_rgba: '#aeb8c1ff'
 - color_rgba: '#2c3294ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01896.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480


### PR DESCRIPTION
Fills out the Amolen PLA Silk Shiny Gradient line with print specifications,                                                                                                 
  per-color photos, and 1kg packages.                                                   
                                                                                                                                                                               
  ### Materials (12)                                                                    
  - Added print/bed temperatures and drying settings from Amolen's official spec:       
    nozzle 210–240 °C, bed 30–65 °C, drying 55 °C for 480 min.                          
  - Density (1.28) and existing colors/tags (silk, gradual_color_change) left unchanged.
  - Added a product photo to all 12 colors (mapped per variant).                        
  - Material `url` set to the product line page; per-variant link lives on the package.                                                                                        
                                                                                        
  ### Packages (12, new)                                                                
  - 1kg packages linking each color to the `amolen-spool-1kg` container,                
    1.75 mm filament, with the per-variant product URL. GTIN-less for now.