### PR TITLE
Add specs, photos, and 1kg packages for Amolen PLA Silk Dual Color

### DIFF
--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-black-blue-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-black-blue-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-black-blue-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760017416215
+material:
+  slug: amolen-pla-silk-dual-color-black-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-black-gold-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-black-gold-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-black-gold-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760057982999
+material:
+  slug: amolen-pla-silk-dual-color-black-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-black-green-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-black-green-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-black-green-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760057950231
+material:
+  slug: amolen-pla-silk-dual-color-black-green
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-black-orange-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-black-orange-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-black-orange-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41795993436183
+material:
+  slug: amolen-pla-silk-dual-color-black-orange
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-black-pink-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-black-pink-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-black-pink-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41795993337879
+material:
+  slug: amolen-pla-silk-dual-color-black-pink
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-black-purple-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-black-purple-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-black-purple-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760057917463
+material:
+  slug: amolen-pla-silk-dual-color-black-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-black-silver-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-black-silver-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-black-silver-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760058146839
+material:
+  slug: amolen-pla-silk-dual-color-black-silver
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-blue-fuchsia-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-blue-fuchsia-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-blue-fuchsia-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760057884695
+material:
+  slug: amolen-pla-silk-dual-color-blue-fuchsia
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-blue-green-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-blue-green-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-blue-green-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760017285143
+material:
+  slug: amolen-pla-silk-dual-color-blue-green
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-blue-green-coral-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-blue-green-coral-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-blue-green-coral-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760017350679
+material:
+  slug: amolen-pla-silk-dual-color-blue-green-coral
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-blue-green-dark-violet-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-blue-green-dark-violet-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-blue-green-dark-violet-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760017317911
+material:
+  slug: amolen-pla-silk-dual-color-blue-green-dark-violet
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-gold-fuchsia-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-gold-fuchsia-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-gold-fuchsia-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760058048535
+material:
+  slug: amolen-pla-silk-dual-color-gold-fuchsia
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-gold-purple-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-gold-purple-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-gold-purple-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760058179607
+material:
+  slug: amolen-pla-silk-dual-color-gold-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-peach-orange-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-peach-orange-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-peach-orange-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760017219607
+material:
+  slug: amolen-pla-silk-dual-color-peach-orange
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-purple-green-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-purple-green-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-purple-green-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760017383447
+material:
+  slug: amolen-pla-silk-dual-color-purple-green
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-red-black-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-red-black-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-red-black-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760017252375
+material:
+  slug: amolen-pla-silk-dual-color-red-black
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-red-blue-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-red-blue-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-red-blue-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760058015767
+material:
+  slug: amolen-pla-silk-dual-color-red-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-red-gold-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-red-gold-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-red-gold-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760058081303
+material:
+  slug: amolen-pla-silk-dual-color-red-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-red-green-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-red-green-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-red-green-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=41760057786391
+material:
+  slug: amolen-pla-silk-dual-color-red-green
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-dual-color-sky-blue-pink-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-dual-color-sky-blue-pink-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-dual-color-sky-blue-pink-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-dual?variant=43057557700631
+material:
+  slug: amolen-pla-silk-dual-color-sky-blue-pink
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/materials/amolen/amolen-pla-silk-dual-color-black-blue.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-black-blue.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Black Blue
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760017416215
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#4921c1ff'
 - color_rgba: '#000000ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/products/818yyFq7pmL._AC_SL1500.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-black-gold.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-black-gold.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Black & Gold
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760057982999
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#000000ff'
 - color_rgba: '#f6c500ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/71Od1D7nPdL._AC_SL1500.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-black-green.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-black-green.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Black & Green
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760057950231
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#000000ff'
 - color_rgba: '#00af66ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/3_6935e536-ed82-49fb-ba8d-8dbc5ecbcf8c.png
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-black-orange.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-black-orange.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Black & Orange
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41795993436183
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#000000ff'
 - color_rgba: '#cf4042ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/2_d95d5c30-923e-4df9-a199-0922615b8f6d.png
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-black-pink.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-black-pink.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Black & Pink
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41795993337879
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#fc6d8eff'
 - color_rgba: '#000000ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/3_50622d4f-3a27-46f5-b96a-5d19f558b061.png
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-black-purple.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-black-purple.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Black & Purple
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760057917463
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#000000ff'
 - color_rgba: '#ba06aeff'
@@ -14,5 +14,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/products/81igCgE.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-black-silver.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-black-silver.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Black & Silver
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760058146839
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#000000ff'
 - color_rgba: '#818184ff'
@@ -14,5 +14,14 @@ tags:
 - coextruded
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/2_434a65ba-569b-48d9-b54f-332c11a57aca.png
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-blue-fuchsia.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-blue-fuchsia.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Blue & Fuchsia
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760057884695
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#2941bdff'
 - color_rgba: '#e23288ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/2_81b4a27c-204a-41f9-a894-458b8244287d.png
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-blue-green-coral.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-blue-green-coral.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Blue Green & Coral
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760017350679
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#63d6d6ff'
 - color_rgba: '#ff2c29ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/2_b9b72136-60c3-4509-90ed-b8921f7fb64d.png
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-blue-green-dark-violet.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-blue-green-dark-violet.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Blue Green & Dark Violet
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760017317911
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#0378d0ff'
 - color_rgba: '#a000caff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/2_b0d731a2-7e85-439e-b7b4-0600c56ddcca.png
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-blue-green.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-blue-green.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Blue Green
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760017285143
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#0bd10bff'
 - color_rgba: '#0078bfff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/2_4f376bc9-05dd-40a2-be4f-56f522a3b55b.png
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-gold-fuchsia.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-gold-fuchsia.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Gold & Fuchsia
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760058048535
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#e23288ff'
 - color_rgba: '#f6c500ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/SKU-06-2in1-GoldFuchsia_1b52bbb7-6575-431a-b18f-9649c09b7ae5.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-gold-purple.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-gold-purple.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Gold & Purple
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760058179607
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#f6c500ff'
 - color_rgba: '#a048f2ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/2_ba2339a1-8fef-4aa4-8656-e7740e1defa3.png
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-peach-orange.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-peach-orange.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Peach Orange
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760017219607
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#eb0075ff'
 - color_rgba: '#f47d59ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/2_ce0c1d72-09aa-4c27-af67-b63bd111f5a3.png
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-purple-green.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-purple-green.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Purple & Green
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760017383447
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#62e480ff'
 - color_rgba: '#be2ed6ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/1_a2e21016-a1e6-4e3d-859d-1f808bfa2de3.png
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-red-black.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-red-black.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Red & Black
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760017252375
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#000000ff'
 - color_rgba: '#ed1536ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/2_8625c91e-b27a-49fd-908d-3d8f49836f32.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-red-blue.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-red-blue.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Red & Blue
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760058015767
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#4921c1ff'
 - color_rgba: '#c80181ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/SKU-10-2in1-blueRed_42805264-56b4-42b6-93d0-7c6b44667ebf.webp
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-red-gold.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-red-gold.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Red & Gold
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760058081303
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#ff0505ff'
 - color_rgba: '#f6c500ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/1-2_1.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-red-green.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-red-green.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Red & Green
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=41760057786391
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#e80078ff'
 - color_rgba: '#2d9e59ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/SKU-14-2in1-RedGreen.webp
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-dual-color-sky-blue-pink.yaml
+++ b/data/materials/amolen/amolen-pla-silk-dual-color-sky-blue-pink.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Dual Color Sky Blue & Pink
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-dual?variant=43057557700631
+url: https://www.amolen.com/products/pla-silk-dual
 secondary_colors:
 - color_rgba: '#40b6e4ff'
 - color_rgba: '#d91ac3ff'
@@ -14,5 +14,14 @@ tags:
 - silk
 - coextruded
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/1_9bff113d-c59b-4576-a8d5-889538b00ce2.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480


### PR DESCRIPTION
  Fills out the Amolen PLA Silk Dual Color line with print specifications,                                                                                                     
  per-color photos, and 1kg packages.                                                   
                                                                                                                                                                               
  ### Materials (20)                                                                    
  - Added print/bed temperatures and drying settings from Amolen's official spec:       
    nozzle 210–240 °C, bed 30–65 °C, drying 55 °C for 480 min.                          
  - Density (1.28) and existing colors/tags (silk, coextruded) left unchanged.          
  - Added a product photo to all 20 colors (mapped per variant).                                                                                                               
  - Material `url` set to the product line page; per-variant link lives on the package.                                                                                        
                                                                                                                                                                               
  ### Packages (20, new)                                                                                                                                                     
  - 1kg packages linking each color to the `amolen-spool-1kg` container,                
    1.75 mm filament, with the per-variant product URL. GTIN-less for now.       