### PR TITLE
Updates for Amolen PLA Silk Basic

### DIFF
--- a/data/material-packages/amolen/amolen-pla-silk-basic-baby-blue-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-baby-blue-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-baby-blue-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=42596034773015
+material:
+  slug: amolen-pla-silk-basic-baby-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-black-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-black-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-black-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=40609108492311
+material:
+  slug: amolen-pla-silk-basic-black
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-black-blue-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-black-blue-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-black-blue-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=40564554661911
+material:
+  slug: amolen-pla-silk-basic-black-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-bronze-green-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-bronze-green-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-bronze-green-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=41399883792407
+material:
+  slug: amolen-pla-silk-basic-bronze-green
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-coffee-gold-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-coffee-gold-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-coffee-gold-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=43048225439767
+material:
+  slug: amolen-pla-silk-basic-coffee-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-cucumber-green-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-cucumber-green-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-cucumber-green-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=42596044308503
+material:
+  slug: amolen-pla-silk-basic-cucumber-green
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-fluoro-yellow-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-fluoro-yellow-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-fluoro-yellow-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=42596041687063
+material:
+  slug: amolen-pla-silk-basic-fluoro-yellow
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-gold-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-gold-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-gold-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=40559559802903
+material:
+  slug: amolen-pla-silk-basic-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-gradient-aged-brass-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-gradient-aged-brass-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-gradient-aged-brass-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=42101544321047
+material:
+  slug: amolen-pla-silk-basic-gradient-aged-brass
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-ice-blue-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-ice-blue-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-ice-blue-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=41646999830551
+material:
+  slug: amolen-pla-silk-basic-ice-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-mercury-silver-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-mercury-silver-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-mercury-silver-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=42454585049111
+material:
+  slug: amolen-pla-silk-basic-mercury-silver
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-neon-green-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-neon-green-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-neon-green-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=42596044963863
+material:
+  slug: amolen-pla-silk-basic-neon-green
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-pink-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-pink-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-pink-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=41076707426327
+material:
+  slug: amolen-pla-silk-basic-pink
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-purple-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-purple-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-purple-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=40616904654871
+material:
+  slug: amolen-pla-silk-basic-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-red-copper-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-red-copper-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-red-copper-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=41368072388631
+material:
+  slug: amolen-pla-silk-basic-red-copper
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-sakura-pink-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-sakura-pink-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-sakura-pink-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=41583203450903
+material:
+  slug: amolen-pla-silk-basic-sakura-pink
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-sapphire-blue-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-sapphire-blue-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-sapphire-blue-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=40564554694679
+material:
+  slug: amolen-pla-silk-basic-sapphire-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-silk-coffee-gold-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-silk-coffee-gold-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-silk-coffee-gold-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=43048225439767
+material:
+  slug: amolen-pla-silk-basic-silk-coffee-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-silk-white-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-silk-white-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-silk-white-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=40547673636887
+material:
+  slug: amolen-pla-silk-basic-silk-white
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-basic-silver-grey-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-basic-silver-grey-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-basic-silver-grey-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-basic?variant=40559559868439
+material:
+  slug: amolen-pla-silk-basic-silver-grey
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/materials/amolen/amolen-pla-silk-basic-baby-blue.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-baby-blue.yaml
@@ -6,11 +6,20 @@ name: PLA Silk Basic Baby Blue
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=42596034773015
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#82e3ecff'
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC00244.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-black.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-black.yaml
@@ -6,11 +6,20 @@ name: PLA Silk Basic Black
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=40609108492311
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#2a3940ff'
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01677.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-bronze-green.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-bronze-green.yaml
@@ -6,11 +6,20 @@ name: PLA Silk Basic Bronze Green
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=41399883792407
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#99a45fff'
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/PLA_Silk_Basic_green-2.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-coffee-gold.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-coffee-gold.yaml
@@ -12,5 +12,14 @@ primary_color:
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/4_ecadc9c5-999e-4c12-a07e-46cc43eb4f73.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-cucumber-green.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-cucumber-green.yaml
@@ -6,11 +6,20 @@ name: PLA Silk Basic Cucumber Green
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=42596044308503
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#6c8c59ff'
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/1-2_fefb164b-b906-4720-b60f-f9607d5d1e03.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-fluoro-yellow.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-fluoro-yellow.yaml
@@ -6,11 +6,20 @@ name: PLA Silk Basic Fluoro Yellow
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=42596041687063
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#eeea44ff'
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC00184.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-gold.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-gold.yaml
@@ -6,11 +6,20 @@ name: PLA Silk Basic Gold
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=40559559802903
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#f4ac23ff'
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01672.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-gradient-aged-brass.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-gradient-aged-brass.yaml
@@ -6,7 +6,7 @@ name: PLA Silk Basic Gradient Aged Brass
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=42101544321047
+url: https://www.amolen.com/products/pla-silk-basic
 secondary_colors:
 - color_rgba: '#606935ff'
 - color_rgba: '#926043ff'
@@ -15,5 +15,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/PLA_Silk_Basic_Silk_Gradient_Aged_Brass.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-ice-blue.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-ice-blue.yaml
@@ -6,11 +6,20 @@ name: PLA Silk Basic Ice Blue
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=41646999830551
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#9fd9f0ff'
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/1-1_1_9fb1a4a2-3bc5-496f-afde-6a87e15be02e.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-mercury-silver.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-mercury-silver.yaml
@@ -1,19 +1,19 @@
-uuid: 09e2d6c3-1ffc-58d3-84f9-3ae0c638ba62
-slug: amolen-pla-silk-basic-black-blue
+uuid: 39faa9f9-49d6-59db-a543-38d6fd75852b
+slug: amolen-pla-silk-basic-mercury-silver
 brand:
   slug: amolen
-name: PLA Silk Basic Black Blue
+name: PLA Silk Basic Mercury Silver
 class: FFF
 type: PLA
 abbreviation: PLA
 url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
-  color_rgba: '#686d93ff'
+  color_rgba: '#c9c1c8ff'
 tags:
 - silk
 - industrially_compostable
 photos:
-- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01618.jpg
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/PLA_Silk_Basic_Mercury_Silver.jpg
   type: unspecified
 properties:
   density: 1.27

--- a/data/materials/amolen/amolen-pla-silk-basic-neon-green.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-neon-green.yaml
@@ -6,12 +6,21 @@ name: PLA Silk Basic Neon Green
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=42596044963863
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#a6ec5fff'
 tags:
 - silk
 - neon
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/PLA_Silk_Basic_green.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-pink.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-pink.yaml
@@ -6,11 +6,20 @@ name: PLA Silk Basic Pink
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=41076707426327
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#fd64b3ff'
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01609.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-purple.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-purple.yaml
@@ -6,11 +6,20 @@ name: PLA Silk Basic Purple
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=40616904654871
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#a000caff'
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/PLA_Silk_Basic_Purple.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-red-copper.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-red-copper.yaml
@@ -6,11 +6,20 @@ name: PLA Silk Basic Red Copper
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=41368072388631
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#ca0230ff'
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01688.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-sakura-pink.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-sakura-pink.yaml
@@ -6,11 +6,20 @@ name: PLA Silk Basic Sakura Pink
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=41583203450903
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#f092b3ff'
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC00136.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-sapphire-blue.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-sapphire-blue.yaml
@@ -6,11 +6,20 @@ name: PLA Silk Basic Sapphire Blue
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=40564554694679
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#0066d9ff'
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/DSC01667.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-silk-coffee-gold.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-silk-coffee-gold.yaml
@@ -11,5 +11,15 @@ primary_color:
   color_rgba: '#b76e34ff'
 tags:
 - silk
+- industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/4_ecadc9c5-999e-4c12-a07e-46cc43eb4f73.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-silk-white.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-silk-white.yaml
@@ -6,11 +6,20 @@ name: PLA Silk Basic Silk White
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=40547673636887
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#f5f5f5ff'
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/PLA_Silk_Basic_White.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-basic-silver-grey.yaml
+++ b/data/materials/amolen/amolen-pla-silk-basic-silver-grey.yaml
@@ -6,11 +6,20 @@ name: PLA Silk Basic Silver Grey
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-silk-basic?variant=40559559868439
+url: https://www.amolen.com/products/pla-silk-basic
 primary_color:
   color_rgba: '#999aa0ff'
 tags:
 - silk
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/PLA_Silk_Basic_Silver_Grey.jpg
+  type: unspecified
 properties:
   density: 1.27
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480


### PR DESCRIPTION
  Fills out the Amolen PLA Silk Basic line with print specifications, per-color
  photos, and 1kg packages, and adds a missing color.

  ### Materials (19 updated)
  - Added print/bed temperatures and drying settings from Amolen's official spec:
    nozzle 210–240 °C, bed 30–65 °C, drying 55 °C for 480 min.
  - Density (1.27) and existing colors left unchanged.
  - Added per-color product photos.
  - Material `url` set to the product line page; per-variant link lives on the package.

  ### New color (1)
  - Mercury Silver (`amolen-pla-silk-basic-mercury-silver`) — was only represented by
    the generic base entry; added as a proper named color with photo and package.

  ### Packages (20, new)
  - 1kg packages linking each color to the `amolen-spool-1kg` container,
    1.75 mm filament, with per-variant product URLs. GTIN-less for now.