### PR TITLE
Updates to Amolen PLA Silk Rainbow series

### DIFF
--- a/data/material-packages/amolen/amolen-pla-silk-rainbow-apple-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-rainbow-apple-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-rainbow-apple-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-rainbow?variant=43042400239639
+material:
+  slug: amolen-pla-silk-rainbow-apple
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-rainbow-bloom-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-rainbow-bloom-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-rainbow-bloom-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-rainbow?variant=42285183631383
+material:
+  slug: amolen-pla-silk-rainbow-bloom
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-rainbow-christmas-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-rainbow-christmas-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-rainbow-christmas-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-rainbow?variant=41718463561751
+material:
+  slug: amolen-pla-silk-rainbow-christmas
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-rainbow-fusion-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-rainbow-fusion-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-rainbow-fusion-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-rainbow?variant=41714671484951
+material:
+  slug: amolen-pla-silk-rainbow-fusion
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-rainbow-kingfisher-blue-yellow-purple-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-rainbow-kingfisher-blue-yellow-purple-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-rainbow-kingfisher-blue-yellow-purple-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-rainbow?variant=40589845463063
+material:
+  slug: amolen-pla-silk-rainbow-kingfisher-blue-yellow-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-rainbow-pink-blue-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-rainbow-pink-blue-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-rainbow-pink-blue-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-rainbow?variant=43042401517591
+material:
+  slug: amolen-pla-silk-rainbow-pink-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-rainbow-shiny-cosmic-rainbow-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-rainbow-shiny-cosmic-rainbow-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-rainbow-shiny-cosmic-rainbow-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-rainbow?variant=40617459941399
+material:
+  slug: amolen-pla-silk-rainbow-shiny-cosmic-rainbow
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-silk-rainbow-yellow-pink-blue-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-silk-rainbow-yellow-pink-blue-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-silk-rainbow-yellow-pink-blue-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-silk-rainbow?variant=31081923805207
+material:
+  slug: amolen-pla-silk-rainbow-yellow-pink-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/materials/amolen/amolen-pla-silk-rainbow-apple.yaml
+++ b/data/materials/amolen/amolen-pla-silk-rainbow-apple.yaml
@@ -15,5 +15,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/2_1_2fb2f548-dec2-41b7-9080-535f32d2390f.png
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-rainbow-bloom.yaml
+++ b/data/materials/amolen/amolen-pla-silk-rainbow-bloom.yaml
@@ -17,5 +17,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/1_37b48e46-a931-47a1-9f2b-2c87941a8fc8.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-rainbow-christmas.yaml
+++ b/data/materials/amolen/amolen-pla-silk-rainbow-christmas.yaml
@@ -17,5 +17,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/1_1_f04b18fc-fbbf-4b2d-8757-00f82a60398a.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-rainbow-fusion.yaml
+++ b/data/materials/amolen/amolen-pla-silk-rainbow-fusion.yaml
@@ -16,5 +16,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/1_1_c3754629-df71-4927-bc2f-1c156d5b5fc3.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-rainbow-kingfisher-blue-yellow-purple.yaml
+++ b/data/materials/amolen/amolen-pla-silk-rainbow-kingfisher-blue-yellow-purple.yaml
@@ -16,5 +16,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/SilkKingfisherBlueYellowPurple.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-rainbow-pink-blue.yaml
+++ b/data/materials/amolen/amolen-pla-silk-rainbow-pink-blue.yaml
@@ -14,5 +14,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/2_0b465549-a784-485e-80f6-d2429867f5d5.png
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-rainbow-shiny-cosmic-rainbow.yaml
+++ b/data/materials/amolen/amolen-pla-silk-rainbow-shiny-cosmic-rainbow.yaml
@@ -16,5 +16,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/products/81B59FuH3PL._AC_SL1500.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-silk-rainbow-yellow-pink-blue.yaml
+++ b/data/materials/amolen/amolen-pla-silk-rainbow-yellow-pink-blue.yaml
@@ -15,5 +15,14 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/71pVAefqW5L._AC_SL1500.jpg
+  type: unspecified
 properties:
   density: 1.28
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480


### PR DESCRIPTION
  Fills out the Amolen PLA Silk Rainbow line with print specifications, per-color
  photos, and 1kg packages.
  
  ### Materials (8)
  - Added print/bed temperatures and drying settings from Amolen's official spec:
    nozzle 210–240 °C, bed 30–65 °C, drying 55 °C for 480 min.
  - Density (1.28) and existing colors/tags (silk, gradual_color_change) left unchanged.
  - Added a product photo to all 8 colors (mapped per variant).
  - Material `url` set to the product line page; per-variant link lives on the package.
  
  ### Packages (8, new)
  - 1kg packages linking each color to the `amolen-spool-1kg` container,
    1.75 mm filament, with the per-variant product URL. GTIN-less for now.