### PR TITLE
Add specs for Amolen PLA Basic-High Speed filament

### DIFF
--- a/data/material-packages/amolen/amolen-pla-basic-high-speed-carrot-orange-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-basic-high-speed-carrot-orange-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-basic-high-speed-carrot-orange-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-basic-high-speed?variant=40616890400791
+material:
+  slug: amolen-pla-basic-high-speed-carrot-orange
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-basic-high-speed-chestnut-brown-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-basic-high-speed-chestnut-brown-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-basic-high-speed-chestnut-brown-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-basic-high-speed?variant=40616864776215
+material:
+  slug: amolen-pla-basic-high-speed-chestnut-brown
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-basic-high-speed-forest-green-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-basic-high-speed-forest-green-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-basic-high-speed-forest-green-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-basic-high-speed?variant=40767918342167
+material:
+  slug: amolen-pla-basic-high-speed-forest-green
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-basic-high-speed-paper-white-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-basic-high-speed-paper-white-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-basic-high-speed-paper-white-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-basic-high-speed?variant=40609057636375
+material:
+  slug: amolen-pla-basic-high-speed-paper-white
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-basic-high-speed-peach-fuzz-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-basic-high-speed-peach-fuzz-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-basic-high-speed-peach-fuzz-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-basic-high-speed?variant=41723932442647
+material:
+  slug: amolen-pla-basic-high-speed-peach-fuzz
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-basic-high-speed-real-gold-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-basic-high-speed-real-gold-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-basic-high-speed-real-gold-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-basic-high-speed?variant=42144824885271
+material:
+  slug: amolen-pla-basic-high-speed-real-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-basic-high-speed-sand-beige-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-basic-high-speed-sand-beige-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-basic-high-speed-sand-beige-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-basic-high-speed?variant=41670965788695
+material:
+  slug: amolen-pla-basic-high-speed-sand-beige
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/materials/amolen/amolen-pla-basic-high-speed-apple-red.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-apple-red.yaml
@@ -14,3 +14,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-army-dark-green.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-army-dark-green.yaml
@@ -14,3 +14,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-butter-yellow.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-butter-yellow.yaml
@@ -14,3 +14,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-carrot-orange.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-carrot-orange.yaml
@@ -6,11 +6,20 @@ name: PLA Basic-High Speed Carrot Orange
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-basic-high-speed?variant=40616890400791
+url: https://www.amolen.com/products/pla-basic-high-speed
 primary_color:
   color_rgba: '#ff7a33ff'
 tags:
 - high_speed
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/2b05e934426ca2edc8e1e126c916b9da.jpg
+  type: unspecified
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-charcoal-black.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-charcoal-black.yaml
@@ -14,3 +14,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-cheese-yellow.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-cheese-yellow.yaml
@@ -14,3 +14,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-chestnut-brown.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-chestnut-brown.yaml
@@ -6,11 +6,20 @@ name: PLA Basic-High Speed Chestnut Brown
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-basic-high-speed?variant=40616864776215
+url: https://www.amolen.com/products/pla-basic-high-speed
 primary_color:
   color_rgba: '#ad4e38ff'
 tags:
 - high_speed
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/3caa193da62f96812ca559b7557b14d2.jpg
+  type: unspecified
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-cream-yellow.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-cream-yellow.yaml
@@ -14,3 +14,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-eggplant-purple.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-eggplant-purple.yaml
@@ -14,3 +14,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-forest-green.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-forest-green.yaml
@@ -6,11 +6,20 @@ name: PLA Basic-High Speed Forest Green
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-basic-high-speed?variant=40767918342167
+url: https://www.amolen.com/products/pla-basic-high-speed
 primary_color:
   color_rgba: '#02776fff'
 tags:
 - high_speed
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/42a8e735d10d4c3df805eaecf26d1763.jpg
+  type: unspecified
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-ice-blue.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-ice-blue.yaml
@@ -14,3 +14,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-koala-grey.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-koala-grey.yaml
@@ -14,3 +14,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-lavender-purple.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-lavender-purple.yaml
@@ -14,3 +14,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-lime-green.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-lime-green.yaml
@@ -14,3 +14,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-matcha-green.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-matcha-green.yaml
@@ -14,3 +14,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-ocean-blue.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-ocean-blue.yaml
@@ -14,3 +14,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-paper-white.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-paper-white.yaml
@@ -6,11 +6,20 @@ name: PLA Basic-High Speed Paper White
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-basic-high-speed?variant=40609057636375
+url: https://www.amolen.com/products/pla-basic-high-speed
 primary_color:
   color_rgba: '#ecefedff'
 tags:
 - high_speed
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/zhibai.jpg
+  type: unspecified
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-peach-fuzz.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-peach-fuzz.yaml
@@ -6,11 +6,20 @@ name: PLA Basic-High Speed Peach Fuzz
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-basic-high-speed?variant=41723932442647
+url: https://www.amolen.com/products/pla-basic-high-speed
 primary_color:
   color_rgba: '#fec8a4ff'
 tags:
 - high_speed
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/0_1_4966f146-3d88-45c0-8468-b1a39c3abf24.jpg
+  type: unspecified
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-real-gold.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-real-gold.yaml
@@ -6,11 +6,20 @@ name: PLA Basic-High Speed Real Gold
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-basic-high-speed?variant=42144824885271
+url: https://www.amolen.com/products/pla-basic-high-speed
 primary_color:
   color_rgba: '#f1bb51ff'
 tags:
 - high_speed
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/d74bab87d921f8f500d6f50957d06210.jpg
+  type: unspecified
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-sakura-pink.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-sakura-pink.yaml
@@ -14,3 +14,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-basic-high-speed-sand-beige.yaml
+++ b/data/materials/amolen/amolen-pla-basic-high-speed-sand-beige.yaml
@@ -6,11 +6,20 @@ name: PLA Basic-High Speed Sand Beige
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-basic-high-speed?variant=41670965788695
+url: https://www.amolen.com/products/pla-basic-high-speed
 primary_color:
   color_rgba: '#d2d9b9ff'
 tags:
 - high_speed
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/52f863efef1f5493e6d386f0a2849f3e.jpg
+  type: unspecified
 properties:
   density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480


### PR DESCRIPTION
  Fills out the Amolen PLA Basic-High Speed line with print specifications, and adds
  photos and 1kg packages for the colors currently sold.
  
  ### Materials (21)
  - Added print/bed temperatures and drying settings from Amolen's official spec to
    all 21 colors: nozzle 190–230 °C, bed 30–65 °C, drying 55 °C for 480 min.
  - Density (1.25) and existing colors/tags left unchanged.
  - For the 7 colors currently listed on amolen.com (Carrot Orange, Chestnut Brown,
    Forest Green, Paper White, Peach Fuzz, Real Gold, Sand Beige): added a product
    photo and set the material `url` to the product line page.
    
  ### Packages (7, new)
  - 1kg packages for the current colors, linked to the `amolen-spool-1kg` container,
    1.75 mm filament, with per-variant product URLs. GTIN-less for now.