### PR TITLE
Amolen matte updates

### DIFF
--- a/data/material-packages/amolen/amolen-pla-matte-basic-navy-blue-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-basic-navy-blue-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-basic-navy-blue-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte?variant=40533368832023
+material:
+  slug: amolen-pla-matte-basic-navy-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-basic-porcelain-white-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-basic-porcelain-white-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-basic-porcelain-white-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte?variant=45103113175063
+material:
+  slug: amolen-pla-matte-basic-porcelain-white
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-basic-sand-beige-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-basic-sand-beige-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-basic-sand-beige-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte?variant=41548833456151
+material:
+  slug: amolen-pla-matte-basic-sand-beige
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-basic-terracotta-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-basic-terracotta-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-basic-terracotta-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte?variant=41607557873687
+material:
+  slug: amolen-pla-matte-basic-terracotta
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-candy-rainbow-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-candy-rainbow-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-candy-rainbow-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-rainbow-filament-1-75mm-1kg-2-2lb?variant=42112112623639
+material:
+  slug: amolen-pla-matte-candy-rainbow
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-dual-color-blue-pink-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-dual-color-blue-pink-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-dual-color-blue-pink-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-dual-filament-1-75mm-1kg-2-2lb?variant=42111989153815
+material:
+  slug: amolen-pla-matte-dual-color-blue-pink
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-dual-color-brown-white-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-dual-color-brown-white-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-dual-color-brown-white-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-dual-filament-1-75mm-1kg-2-2lb?variant=42111989219351
+material:
+  slug: amolen-pla-matte-dual-color-brown-white
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-dual-color-cyan-chartreuse-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-dual-color-cyan-chartreuse-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-dual-color-cyan-chartreuse-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-dual-filament-1-75mm-1kg-2-2lb?variant=42111988432919
+material:
+  slug: amolen-pla-matte-dual-color-cyan-chartreuse
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-dual-color-green-purple-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-dual-color-green-purple-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-dual-color-green-purple-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-dual-filament-1-75mm-1kg-2-2lb?variant=42111988563991
+material:
+  slug: amolen-pla-matte-dual-color-green-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-dual-color-peach-gold-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-dual-color-peach-gold-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-dual-color-peach-gold-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-dual-filament-1-75mm-1kg-2-2lb?variant=43054307082263
+material:
+  slug: amolen-pla-matte-dual-color-peach-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-dual-color-pink-purple-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-dual-color-pink-purple-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-dual-color-pink-purple-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-dual-filament-1-75mm-1kg-2-2lb?variant=42111989284887
+material:
+  slug: amolen-pla-matte-dual-color-pink-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-dual-color-red-gold-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-dual-color-red-gold-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-dual-color-red-gold-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-dual-filament-1-75mm-1kg-2-2lb?variant=42111989350423
+material:
+  slug: amolen-pla-matte-dual-color-red-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-lemon-mint-rainbow-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-lemon-mint-rainbow-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-lemon-mint-rainbow-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-rainbow-filament-1-75mm-1kg-2-2lb?variant=42112112230423
+material:
+  slug: amolen-pla-matte-lemon-mint-rainbow
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-multicolor-rainbow-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-multicolor-rainbow-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-multicolor-rainbow-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-rainbow-filament-1-75mm-1kg-2-2lb?variant=42112112689175
+material:
+  slug: amolen-pla-matte-multicolor-rainbow
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-pastel-berry-rainbow-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-pastel-berry-rainbow-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-pastel-berry-rainbow-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-rainbow-filament-1-75mm-1kg-2-2lb?variant=42112112754711
+material:
+  slug: amolen-pla-matte-pastel-berry-rainbow
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-rosy-rainbow-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-rosy-rainbow-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-rosy-rainbow-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-rainbow-filament-1-75mm-1kg-2-2lb?variant=43040517324823
+material:
+  slug: amolen-pla-matte-rosy-rainbow
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-sunset-rainbow-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-sunset-rainbow-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-sunset-rainbow-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-rainbow-filament-1-75mm-1kg-2-2lb?variant=42112112820247
+material:
+  slug: amolen-pla-matte-sunset-rainbow
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-triple-color-pink-cyan-chartreuse-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-triple-color-pink-cyan-chartreuse-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-triple-color-pink-cyan-chartreuse-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-triple-filament-1-75mm-1kg-2-2lb?variant=42112075464727
+material:
+  slug: amolen-pla-matte-triple-color-pink-cyan-chartreuse
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-triple-color-red-yellow-blue-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-triple-color-red-yellow-blue-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-triple-color-red-yellow-blue-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-triple-filament-1-75mm-1kg-2-2lb?variant=42112075530263
+material:
+  slug: amolen-pla-matte-triple-color-red-yellow-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/amolen/amolen-pla-matte-triple-white-pink-purple-1kg.yaml
+++ b/data/material-packages/amolen/amolen-pla-matte-triple-white-pink-purple-1kg.yaml
@@ -1,0 +1,9 @@
+slug: amolen-pla-matte-triple-white-pink-purple-1kg
+class: FFF
+url: https://www.amolen.com/products/pla-matte-triple-filament-1-75mm-1kg-2-2lb?variant=42112075595799
+material:
+  slug: amolen-pla-matte-triple-white-pink-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: amolen-spool-1kg
+filament_diameter: 1750

--- a/data/materials/amolen/amolen-pla-matte-basic-amolen-blue.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-amolen-blue.yaml
@@ -6,7 +6,6 @@ name: PLA Matte Basic Amolen Blue
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-matte?variant=42454614212631
 primary_color:
   color_rgba: '#4f03d7ff'
 tags:
@@ -14,3 +13,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-black.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-black.yaml
@@ -6,7 +6,6 @@ name: PLA Matte Basic Black
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-matte?variant=41705655631895
 primary_color:
   color_rgba: '#3b353aff'
 tags:
@@ -15,4 +14,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-basic-black/f3102a0f43e1.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-chocolate-brown.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-chocolate-brown.yaml
@@ -6,7 +6,6 @@ name: PLA Matte Basic Chocolate Brown
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-matte?variant=42454614278167
 primary_color:
   color_rgba: '#9c5949ff'
 tags:
@@ -14,3 +13,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-ice-blue.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-ice-blue.yaml
@@ -14,4 +14,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-basic-ice-blue/a53ea440812f.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-lemon-yellow.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-lemon-yellow.yaml
@@ -14,4 +14,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-basic-lemon-yellow/94b3b788f139.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-lilac-purple.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-lilac-purple.yaml
@@ -14,4 +14,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-basic-lilac-purple/e99acaad5bcd.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-navy-blue.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-navy-blue.yaml
@@ -14,4 +14,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-basic-navy-blue/4edc9dd5add9.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-olive-green.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-olive-green.yaml
@@ -6,7 +6,6 @@ name: PLA Matte Basic Olive Green
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-matte?variant=40533369094167
 primary_color:
   color_rgba: '#748c45ff'
 tags:
@@ -17,3 +16,9 @@ photos:
   type: unspecified
 properties:
   density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-pale-peach.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-pale-peach.yaml
@@ -14,4 +14,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-basic-pale-peach/0093c8a749f3.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-porcelain-white.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-porcelain-white.yaml
@@ -6,11 +6,19 @@ name: PLA Matte Basic Porcelain White
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-matte?variant=43739431239703
 primary_color:
   color_rgba: '#e3e0d3ff'
 tags:
 - matte
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/0_4923fc28-cef4-4de5-bd54-6c5ac1e11fa1.jpg
+  type: unspecified
 properties:
   density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-purple.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-purple.yaml
@@ -6,7 +6,6 @@ name: PLA Matte Basic Purple
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-matte?variant=43739431305239
 primary_color:
   color_rgba: '#7f068cff'
 tags:
@@ -14,3 +13,9 @@ tags:
 - industrially_compostable
 properties:
   density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-quartz-white.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-quartz-white.yaml
@@ -14,4 +14,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-basic-quartz-white/8b950dcb36ef.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-sakura-pink.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-sakura-pink.yaml
@@ -14,4 +14,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-basic-sakura-pink/fa3b1bd27d0b.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-sand-beige.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-sand-beige.yaml
@@ -14,4 +14,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-basic-sand-beige/34344737e575.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-sunny-orange.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-sunny-orange.yaml
@@ -14,4 +14,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-basic-sunny-orange/6230bde2b90d.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-terracotta.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-terracotta.yaml
@@ -14,4 +14,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-basic-terracotta/da3c291b941c.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-wasabi-green.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-wasabi-green.yaml
@@ -14,4 +14,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-basic-wasabi-green/e501c8085bd6.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-basic-watermelon-red.yaml
+++ b/data/materials/amolen/amolen-pla-matte-basic-watermelon-red.yaml
@@ -14,4 +14,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-basic-watermelon-red/720de7b84b7b.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-candy-rainbow.yaml
+++ b/data/materials/amolen/amolen-pla-matte-candy-rainbow.yaml
@@ -19,4 +19,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-candy-rainbow/c7498c29ecaa.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-dual-color-blue-pink.yaml
+++ b/data/materials/amolen/amolen-pla-matte-dual-color-blue-pink.yaml
@@ -16,4 +16,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-dual-color-blue-pink/cf44cae8acb0.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-dual-color-brown-white.yaml
+++ b/data/materials/amolen/amolen-pla-matte-dual-color-brown-white.yaml
@@ -16,4 +16,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-dual-color-brown-white/f042d6aeacd8.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-dual-color-cyan-chartreuse.yaml
+++ b/data/materials/amolen/amolen-pla-matte-dual-color-cyan-chartreuse.yaml
@@ -16,4 +16,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-dual-color-cyan-chartreuse/eaeba5d398d2.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-dual-color-green-purple.yaml
+++ b/data/materials/amolen/amolen-pla-matte-dual-color-green-purple.yaml
@@ -16,4 +16,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-dual-color-green-purple/9b9f1613956f.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-dual-color-peach-gold.yaml
+++ b/data/materials/amolen/amolen-pla-matte-dual-color-peach-gold.yaml
@@ -6,7 +6,6 @@ name: PLA Matte Dual Color Peach Gold
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-matte-dual-filament-1-75mm-1kg-2-2lb?variant=43054307082263
 secondary_colors:
 - color_rgba: '#eb5274ff'
 - color_rgba: '#f7d979ff'
@@ -17,4 +16,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-dual-color-peach-gold/c7921d389039.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-dual-color-pink-purple.yaml
+++ b/data/materials/amolen/amolen-pla-matte-dual-color-pink-purple.yaml
@@ -16,4 +16,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-dual-color-pink-purple/2.2LB
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-dual-color-red-gold.yaml
+++ b/data/materials/amolen/amolen-pla-matte-dual-color-red-gold.yaml
@@ -16,4 +16,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-dual-color-red-gold/b8391807c665.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-lemon-mint-rainbow.yaml
+++ b/data/materials/amolen/amolen-pla-matte-lemon-mint-rainbow.yaml
@@ -6,7 +6,6 @@ name: PLA Matte Lemon Mint Rainbow
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-matte-rainbow-filament-1-75mm-1kg-2-2lb?variant=42112112230423
 secondary_colors:
 - color_rgba: '#d9d4c6ff'
 - color_rgba: '#d6ea65ff'
@@ -16,5 +15,14 @@ tags:
 - matte
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/Lemon_Mint_Rainbow.jpg
+  type: unspecified
 properties:
   density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-multicolor-rainbow.yaml
+++ b/data/materials/amolen/amolen-pla-matte-multicolor-rainbow.yaml
@@ -18,4 +18,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-multicolor-rainbow/d339ddf6cfdf.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-pastel-berry-rainbow.yaml
+++ b/data/materials/amolen/amolen-pla-matte-pastel-berry-rainbow.yaml
@@ -6,7 +6,6 @@ name: PLA Matte Pastel Berry Rainbow
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-matte-rainbow-filament-1-75mm-1kg-2-2lb?variant=42112112754711
 secondary_colors:
 - color_rgba: '#4d99b0ff'
 - color_rgba: '#f5cf6fff'
@@ -17,5 +16,14 @@ tags:
 - matte
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/Pastel_Rainbow.jpg
+  type: unspecified
 properties:
   density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-rosy-rainbow.yaml
+++ b/data/materials/amolen/amolen-pla-matte-rosy-rainbow.yaml
@@ -6,7 +6,6 @@ name: PLA Matte Rosy Rainbow
 class: FFF
 type: PLA
 abbreviation: PLA
-url: https://www.amolen.com/products/pla-matte-rainbow-filament-1-75mm-1kg-2-2lb?variant=43040517324823
 secondary_colors:
 - color_rgba: '#fe0193ff'
 - color_rgba: '#f7a7a1ff'
@@ -15,5 +14,14 @@ tags:
 - matte
 - gradual_color_change
 - industrially_compostable
+photos:
+- url: https://cdn.shopify.com/s/files/1/0019/2924/8803/files/1_d50cbf71-9439-4289-a42c-902a224111d0.jpg
+  type: unspecified
 properties:
   density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-sunset-rainbow.yaml
+++ b/data/materials/amolen/amolen-pla-matte-sunset-rainbow.yaml
@@ -17,4 +17,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-sunset-rainbow/c7133be90d8f.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-triple-color-pink-cyan-chartreuse.yaml
+++ b/data/materials/amolen/amolen-pla-matte-triple-color-pink-cyan-chartreuse.yaml
@@ -17,4 +17,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-triple-color-pink-cyan-chartreuse/68b838d88581.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-triple-color-red-yellow-blue.yaml
+++ b/data/materials/amolen/amolen-pla-matte-triple-color-red-yellow-blue.yaml
@@ -17,4 +17,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-triple-color-red-yellow-blue/49860c5dd4ba.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/amolen/amolen-pla-matte-triple-white-pink-purple.yaml
+++ b/data/materials/amolen/amolen-pla-matte-triple-white-pink-purple.yaml
@@ -17,4 +17,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/amolen/amolen-pla-matte-triple-white-pink-purple/b1ef12b2e2b7.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.24
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 30
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480


### PR DESCRIPTION
 Fills out the four Amolen PLA Matte product lines with print specifications, photos, and
  1kg packages, and backfills specs on discontinued colors.
  
  ### Live products — full update (20 colors)
  - PLA Matte Basic (4): Navy Blue, Porcelain White, Sand Beige, Terracotta
  - PLA Matte Dual (7): Blue Pink, Brown White, Cyan Chartreuse, Green Purple, Peach Gold, Pink Purple, Red Gold
  - PLA Matte Triple (3): Pink Cyan Chartreuse, Red Yellow Blue, White Pink Purple
  - PLA Matte Rainbow (6): Candy, Lemon Mint, Multicolor, Pastel Berry, Rosy, Sunset
  
  Each got print/bed temperatures and drying settings (nozzle 190–230 °C, bed
  30–65 °C, drying 55 °C for 480 min), density 1.24, the product line `url`, a photo
  where missing, and a new 1kg package (linked to `amolen-spool-1kg`, 1.75 mm).
  
  ### Discontinued Basic colors (14)
  - Specs only (temps/drying + density 1.24); existing photos kept; no packages, as
    these are no longer listed for sale but may still be in use.
    
  ### Packages (20, new)
  - 1kg packages for all current colors, with per-variant product URLs. GTIN-less for now.