### PR TITLE
Add specs and 1kg packages for ELEGOO PLA line

### DIFF
--- a/data/material-packages/elegoo/elegoo-pla-beige-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-beige-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-beige-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-112
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734134227125
+material:
+  slug: elegoo-pla-beige
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-black-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-black-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-black-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3D-P01
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734133670069
+material:
+  slug: elegoo-pla-black
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-brown-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-brown-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-brown-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-111
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734134194357
+material:
+  slug: elegoo-pla-brown
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-dark-blue-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-dark-blue-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-dark-blue-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3D-P05N
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734133801141
+material:
+  slug: elegoo-pla-dark-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-grey-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-grey-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-grey-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3D-P03
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734133735605
+material:
+  slug: elegoo-pla-grey
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-neon-green-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-neon-green-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-neon-green-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3D-P04N
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734133768373
+material:
+  slug: elegoo-pla-neon-green
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-orange-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-orange-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-orange-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3D-P08N
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734133899445
+material:
+  slug: elegoo-pla-orange
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-pink-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-pink-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-pink-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-102
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734133964981
+material:
+  slug: elegoo-pla-pink
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-purple-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-purple-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-purple-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-103
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734133997749
+material:
+  slug: elegoo-pla-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-red-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-red-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-red-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3D-P06
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734133833909
+material:
+  slug: elegoo-pla-red
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-sea-green-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-sea-green-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-sea-green-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-106
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734134096053
+material:
+  slug: elegoo-pla-sea-green
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-sky-blue-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-sky-blue-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-sky-blue-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-105
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734134063285
+material:
+  slug: elegoo-pla-sky-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-space-grey-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-space-grey-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-space-grey-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-107
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734134128821
+material:
+  slug: elegoo-pla-space-grey
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-white-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-white-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-white-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3D-P02
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734133702837
+material:
+  slug: elegoo-pla-white
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-wood-color-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-wood-color-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-wood-color-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-109
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734134161589
+material:
+  slug: elegoo-pla-wood-color
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pla-yellow-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pla-yellow-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pla-yellow-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3D-P07
+url: https://us.elegoo.com/products/pla-filament-1-75mm-colored-1kg?variant=43734133866677
+material:
+  slug: elegoo-pla-yellow
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/materials/elegoo/elegoo-pla-beige.yaml
+++ b/data/materials/elegoo/elegoo-pla-beige.yaml
@@ -13,4 +13,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-beige/2a0d493b20fd.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-black.yaml
+++ b/data/materials/elegoo/elegoo-pla-black.yaml
@@ -13,4 +13,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-black/12c32922790a.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-brown.yaml
+++ b/data/materials/elegoo/elegoo-pla-brown.yaml
@@ -13,4 +13,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-brown/d688b9419582.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-dark-blue.yaml
+++ b/data/materials/elegoo/elegoo-pla-dark-blue.yaml
@@ -13,4 +13,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-dark-blue/d343bdc0e4ad.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-grey.yaml
+++ b/data/materials/elegoo/elegoo-pla-grey.yaml
@@ -13,4 +13,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-grey/e01bd06f6d2e.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-neon-green.yaml
+++ b/data/materials/elegoo/elegoo-pla-neon-green.yaml
@@ -14,4 +14,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-neon-green/cf0946f3abf2.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-orange.yaml
+++ b/data/materials/elegoo/elegoo-pla-orange.yaml
@@ -13,4 +13,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-orange/2af766e6a567.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-pink.yaml
+++ b/data/materials/elegoo/elegoo-pla-pink.yaml
@@ -13,4 +13,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-pink/f47e71f557b5.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-purple.yaml
+++ b/data/materials/elegoo/elegoo-pla-purple.yaml
@@ -13,4 +13,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-purple/611c819d2e55.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-red.yaml
+++ b/data/materials/elegoo/elegoo-pla-red.yaml
@@ -13,4 +13,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-red/30a9fffc2221.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-sea-green.yaml
+++ b/data/materials/elegoo/elegoo-pla-sea-green.yaml
@@ -13,4 +13,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-sea-green/c359107e8ca1.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-sky-blue.yaml
+++ b/data/materials/elegoo/elegoo-pla-sky-blue.yaml
@@ -13,4 +13,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-sky-blue/32f6358858c1.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-space-grey.yaml
+++ b/data/materials/elegoo/elegoo-pla-space-grey.yaml
@@ -13,4 +13,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-space-grey/c451c6c54087.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-white.yaml
+++ b/data/materials/elegoo/elegoo-pla-white.yaml
@@ -13,4 +13,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-white/b7dd39514b46.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-wood-color.yaml
+++ b/data/materials/elegoo/elegoo-pla-wood-color.yaml
@@ -14,4 +14,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-wood-color/00915a19a3ca.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pla-yellow.yaml
+++ b/data/materials/elegoo/elegoo-pla-yellow.yaml
@@ -13,4 +13,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-pla-yellow/ef50231c7832.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.26
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 200


### PR DESCRIPTION
Standardizes the ELEGOO PLA line (the standard spooled PLA, non-RFID) with print specifications and 1kg packages. 

  ### Materials (16)
  - Added `properties` from ELEGOO's spec sheet: nozzle 190–230 °C, bed 35–65 °C,
    density 1.26, drying 50 °C for 480 min, min nozzle 0.2 mm. Existing colors/photos/
    tags unchanged.
  - Added the product line `url` to each material.
 
  ### Packages (16, new)
  - 1kg packages on the `elegoo-cardboard-spool-1kg` container, 1.75 mm, each with its
    ELEGOO SKU (`brand_specific_id`) and the per-variant product URL.

  Colors: Black, White, Grey, Neon Green, Dark Blue, Red, Yellow, Orange, Pink, Purple,   Sky Blue, Sea Green, Space Grey, Wood Color, Brown, Beige. (Translucent was already in the DB; the RFID variants share the same material and are omitted pending schema guidance.)