### PR TITLE
Updates for ELEGOO PLA Silk line

### DIFF
--- a/data/material-containers/elegoo-plastic-spool-1kg.yaml
+++ b/data/material-containers/elegoo-plastic-spool-1kg.yaml
@@ -1,0 +1,11 @@
+uuid: 8d78a5d4-3b9b-4394-83d8-5dd42e504ac0
+slug: elegoo-plastic-spool-1kg
+name: ELEGOO Plastic Spool 1kg
+class: FFF
+brand:
+  slug: elegoo
+hole_diameter: 57.4
+inner_diameter: 95
+outer_diameter: 198
+width: 65
+empty_weight: 174

--- a/data/material-packages/elegoo/elegoo-silk-pla-black-purple-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-silk-pla-black-purple-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-silk-pla-black-purple-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-127
+url: https://us.elegoo.com/products/elegoo-silk-pla-filament-1-75mm-colored-1kg?variant=44833148731573
+material:
+  slug: elegoo-silk-pla-black-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-silk-pla-black-red-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-silk-pla-black-red-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-silk-pla-black-red-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-119
+url: https://us.elegoo.com/products/elegoo-silk-pla-filament-1-75mm-colored-1kg?variant=44561620730037
+material:
+  slug: elegoo-silk-pla-black-red
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-silk-pla-blue-green-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-silk-pla-blue-green-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-silk-pla-blue-green-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-128
+url: https://us.elegoo.com/products/elegoo-silk-pla-filament-1-75mm-colored-1kg?variant=44833148764341
+material:
+  slug: elegoo-silk-pla-blue-green
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-silk-pla-blue-green-orange-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-silk-pla-blue-green-orange-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-silk-pla-blue-green-orange-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-121
+url: https://us.elegoo.com/products/elegoo-silk-pla-filament-1-75mm-colored-1kg?variant=44561620795573
+material:
+  slug: elegoo-silk-pla-blue-green-orange
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-silk-pla-blue-purple-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-silk-pla-blue-purple-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-silk-pla-blue-purple-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-115N
+url: https://us.elegoo.com/products/elegoo-silk-pla-filament-1-75mm-colored-1kg?variant=51865636077749
+material:
+  slug: elegoo-silk-pla-blue-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-silk-pla-blue-purple-black-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-silk-pla-blue-purple-black-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-silk-pla-blue-purple-black-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-120
+url: https://us.elegoo.com/products/elegoo-silk-pla-filament-1-75mm-colored-1kg?variant=44561620762805
+material:
+  slug: elegoo-silk-pla-blue-purple-black
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-silk-pla-coral-pink-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-silk-pla-coral-pink-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-silk-pla-coral-pink-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-116
+url: https://us.elegoo.com/products/elegoo-silk-pla-filament-1-75mm-colored-1kg?variant=43734189179061
+material:
+  slug: elegoo-silk-pla-coral-pink
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-silk-pla-gold-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-silk-pla-gold-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-silk-pla-gold-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3D-S01
+url: https://us.elegoo.com/products/elegoo-silk-pla-filament-1-75mm-colored-1kg?variant=43734189047989
+material:
+  slug: elegoo-silk-pla-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-silk-pla-green-red-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-silk-pla-green-red-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-silk-pla-green-red-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3D-S02
+url: https://us.elegoo.com/products/elegoo-silk-pla-filament-1-75mm-colored-1kg?variant=43734189080757
+material:
+  slug: elegoo-silk-pla-green-red
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-silk-pla-holly-green-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-silk-pla-holly-green-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-silk-pla-holly-green-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-123
+url: https://us.elegoo.com/products/elegoo-silk-pla-filament-1-75mm-colored-1kg?variant=44336275161269
+material:
+  slug: elegoo-silk-pla-holly-green
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-silk-pla-mint-green-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-silk-pla-mint-green-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-silk-pla-mint-green-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-117
+url: https://us.elegoo.com/products/elegoo-silk-pla-filament-1-75mm-colored-1kg?variant=43734189211829
+material:
+  slug: elegoo-silk-pla-mint-green
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-silk-pla-white-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-silk-pla-white-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-silk-pla-white-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PLA-129
+url: https://us.elegoo.com/products/elegoo-silk-pla-filament-1-75mm-colored-1kg?variant=44833148698805
+material:
+  slug: elegoo-silk-pla-white
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/materials/elegoo/elegoo-silk-pla-black-purple.yaml
+++ b/data/materials/elegoo/elegoo-silk-pla-black-purple.yaml
@@ -16,4 +16,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-silk-pla-black-purple/0fe263cd59b3.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 400

--- a/data/materials/elegoo/elegoo-silk-pla-black-red.yaml
+++ b/data/materials/elegoo/elegoo-silk-pla-black-red.yaml
@@ -16,4 +16,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-silk-pla-black-red/7dad039996bb.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 400

--- a/data/materials/elegoo/elegoo-silk-pla-blue-green-orange.yaml
+++ b/data/materials/elegoo/elegoo-silk-pla-blue-green-orange.yaml
@@ -17,4 +17,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-silk-pla-blue-green-orange/4272a880041a.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 400

--- a/data/materials/elegoo/elegoo-silk-pla-blue-green.yaml
+++ b/data/materials/elegoo/elegoo-silk-pla-blue-green.yaml
@@ -16,4 +16,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-silk-pla-blue-green/687c7c958764.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 400

--- a/data/materials/elegoo/elegoo-silk-pla-blue-purple-black.yaml
+++ b/data/materials/elegoo/elegoo-silk-pla-blue-purple-black.yaml
@@ -17,4 +17,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-silk-pla-blue-purple-black/7e09f56bc71b.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 400

--- a/data/materials/elegoo/elegoo-silk-pla-blue-purple.yaml
+++ b/data/materials/elegoo/elegoo-silk-pla-blue-purple.yaml
@@ -16,4 +16,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-silk-pla-blue-purple/1e1698fecf4c.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 400

--- a/data/materials/elegoo/elegoo-silk-pla-coral-pink.yaml
+++ b/data/materials/elegoo/elegoo-silk-pla-coral-pink.yaml
@@ -14,4 +14,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-silk-pla-coral-pink/0db294537740.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 400

--- a/data/materials/elegoo/elegoo-silk-pla-gold.yaml
+++ b/data/materials/elegoo/elegoo-silk-pla-gold.yaml
@@ -14,4 +14,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-silk-pla-gold/4810fdd6ec99.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 400

--- a/data/materials/elegoo/elegoo-silk-pla-green-red.yaml
+++ b/data/materials/elegoo/elegoo-silk-pla-green-red.yaml
@@ -16,4 +16,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-silk-pla-green-red/a883807d34b8.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 400

--- a/data/materials/elegoo/elegoo-silk-pla-holly-green.yaml
+++ b/data/materials/elegoo/elegoo-silk-pla-holly-green.yaml
@@ -14,4 +14,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-silk-pla-holly-green/f134d1bdaa6e.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 400

--- a/data/materials/elegoo/elegoo-silk-pla-mint-green.yaml
+++ b/data/materials/elegoo/elegoo-silk-pla-mint-green.yaml
@@ -14,4 +14,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-silk-pla-mint-green/2e131d725e7f.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 400

--- a/data/materials/elegoo/elegoo-silk-pla-white.yaml
+++ b/data/materials/elegoo/elegoo-silk-pla-white.yaml
@@ -14,4 +14,12 @@ tags:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-silk-pla-white/6a1f927d0f7e.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.25
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 35
+  max_bed_temperature: 65
+  drying_temperature: 50
+  drying_time: 480
+  min_nozzle_diameter: 400


### PR DESCRIPTION
Standardizes the ELEGOO PLA Silk line with print specifications and 1kg packages,
and adds the plastic spool container these ship on.

### Container (new)
- `elegoo-plastic-spool-1kg` — ELEGOO's 174 g plastic spool (hole 57.4 / inner 95 /
  outer 198 / width 65 mm).

### Materials (12)
- Added `properties` from ELEGOO's Silk spec sheet: nozzle 190–230 °C, bed 35–65 °C,
  density 1.25, drying 50 °C for 480 min, min nozzle 0.4 mm. Colors/photos/tags unchanged.
- Added the product line `url` to each material.

### Packages (12, new)
- 1kg packages on `elegoo-plastic-spool-1kg`, 1.75 mm, each with its ELEGOO SKU
  (`brand_specific_id`) and per-variant product URL.

Covers the 12 Silk colors currently in the database that are still listed on
elegoo.com. 