### PR TITLE
Add specs and 1kg packages for ELEGOO PC line

### DIFF
--- a/data/material-packages/elegoo/elegoo-pc-black-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pc-black-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pc-black-1kg
+class: FFF
+brand_specific_id: SPUS-EL-EPC-001
+url: https://us.elegoo.com/products/pc-filament-1-75mm-colored-1kg?variant=51248332308661
+material:
+  slug: elegoo-pc-black
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pc-clear-black-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pc-clear-black-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pc-clear-black-1kg
+class: FFF
+brand_specific_id: SPUS-EL-EPC-003
+url: https://us.elegoo.com/products/pc-filament-1-75mm-colored-1kg?variant=51248332374197
+material:
+  slug: elegoo-pc-clear-black
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pc-transparent-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pc-transparent-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pc-transparent-1kg
+class: FFF
+brand_specific_id: SPUS-EL-EPC-004
+url: https://us.elegoo.com/products/pc-filament-1-75mm-colored-1kg?variant=51248332406965
+material:
+  slug: elegoo-pc-transparent
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-pc-white-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-pc-white-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-pc-white-1kg
+class: FFF
+brand_specific_id: SPUS-EL-EPC-002
+url: https://us.elegoo.com/products/pc-filament-1-75mm-colored-1kg?variant=51248332341429
+material:
+  slug: elegoo-pc-white
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/materials/elegoo/elegoo-pc-black.yaml
+++ b/data/materials/elegoo/elegoo-pc-black.yaml
@@ -1,0 +1,24 @@
+uuid: a97311bb-8bf8-529d-b938-3e3172538c4b
+slug: elegoo-pc-black
+brand:
+  slug: elegoo
+name: PC Black
+class: FFF
+type: PC
+abbreviation: PC
+primary_color:
+  color_rgba: '#00000000'
+photos:
+- url: https://cdn.shopify.com/s/files/1/0639/7660/3829/files/PC1KG_1.75mm_d147a3bc-9fb2-48f3-be2f-d13fbe8b20c6.jpg?v=1750652570
+  type: unspecified
+properties:
+  density: 1.2
+  min_print_temperature: 250
+  max_print_temperature: 270
+  min_bed_temperature: 90
+  max_bed_temperature: 110
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60
+  drying_temperature: 80
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pc-clear-black.yaml
+++ b/data/materials/elegoo/elegoo-pc-clear-black.yaml
@@ -1,0 +1,24 @@
+uuid: aec46a16-fd60-50b2-9c6b-d39c8b34aded
+slug: elegoo-pc-clear-black
+brand:
+  slug: elegoo
+name: PC Clear Black
+class: FFF
+type: PC
+abbreviation: PC
+primary_color:
+  color_rgba: '#3e4654ff'
+photos:
+- url: https://cdn.shopify.com/s/files/1/0639/7660/3829/files/PC1KG_1.75mm_5ace859a-fb8f-4df4-933b-7249a2aa4483.jpg?v=1750652570
+  type: unspecified
+properties:
+  density: 1.2
+  min_print_temperature: 250
+  max_print_temperature: 270
+  min_bed_temperature: 90
+  max_bed_temperature: 110
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60
+  drying_temperature: 80
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pc-transparent.yaml
+++ b/data/materials/elegoo/elegoo-pc-transparent.yaml
@@ -1,0 +1,24 @@
+uuid: c74b5ff5-6fbd-5cef-9abb-4bffd5bf557a
+slug: elegoo-pc-transparent
+brand:
+  slug: elegoo
+name: PC Transparent
+class: FFF
+type: PC
+abbreviation: PC
+primary_color:
+  color_rgba: '#b0b0b0ff'
+photos:
+- url: https://cdn.shopify.com/s/files/1/0639/7660/3829/files/PC1KG_1.75mm_b9b0fa88-9c8b-4426-a2dd-150880846ead.jpg?v=1750652570
+  type: unspecified
+properties:
+  density: 1.2
+  min_print_temperature: 250
+  max_print_temperature: 270
+  min_bed_temperature: 90
+  max_bed_temperature: 110
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60
+  drying_temperature: 80
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-pc-white.yaml
+++ b/data/materials/elegoo/elegoo-pc-white.yaml
@@ -1,0 +1,24 @@
+uuid: a8ee0c27-34a0-58b4-980b-51a2c7692363
+slug: elegoo-pc-white
+brand:
+  slug: elegoo
+name: PC White
+class: FFF
+type: PC
+abbreviation: PC
+primary_color:
+  color_rgba: '#ffffffff'
+photos:
+- url: https://cdn.shopify.com/s/files/1/0639/7660/3829/files/PC1KG_1.75mm_219af313-d639-48ea-8948-4ee25d4c2b69.jpg?v=1750652570
+  type: unspecified
+properties:
+  density: 1.2
+  min_print_temperature: 250
+  max_print_temperature: 270
+  min_bed_temperature: 90
+  max_bed_temperature: 110
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60
+  drying_temperature: 80
+  drying_time: 480
+  min_nozzle_diameter: 200


### PR DESCRIPTION
Adds the ELEGOO PC (polycarbonate) line — 4 colors, each a new material plus a
  1kg package on the existing ELEGOO cardboard spool. 
  
  ### Materials (4, new)
  - PC Black, PC White, PC Clear Black, PC Transparent
  - `type: PC`, 1.75 mm, photos per color (manufacturer CDN)
  - Properties from the official ELEGOO PC spec sheet:
    - Nozzle 250–270 °C, bed 90–110 °C, chamber 45–60 °C (enclosure required)
    - Drying 80 °C / 8 h, density 1.20 g/cm³, recommended nozzle ≥0.2 mm
  - Spec-sheet values with no schema field (melt index, melting temp, Vicat, HDT,
    tensile/elongation/bending/impact, print speed, humidity) are omitted.
    
  ### Packages (4, new)
  - `elegoo-pc-{color}-1kg`, 1000 g, 1.75 mm, on `elegoo-cardboard-spool-1kg`
  - `brand_specific_id` = ELEGOO SKU (SPUS-EL-EPC-00x); variant product URL on the package
  - GTIN-less for now (no barcodes on the listing) — backfillable later 
  
  Product: https://us.elegoo.com/products/pc-filament-1-75mm-colored-1kg
  `make validate` passes; README/manifest untouched.