### PR TITLE
Add ERYONE PLA Silk lines (single, dual, triple) with specs, packages, and cardboard spool

### DIFF
--- a/data/material-containers/eryone-cardboard-spool-1kg.yaml
+++ b/data/material-containers/eryone-cardboard-spool-1kg.yaml
@@ -1,0 +1,10 @@
+uuid: 54bc954d-3203-42e7-ab0c-e45e08119198
+slug: eryone-cardboard-spool-1kg
+name: ERYONE Cardboard Spool 1kg
+class: FFF
+brand:
+  slug: eryone
+hole_diameter: 57
+outer_diameter: 200
+width: 64
+empty_weight: 156

--- a/data/material-packages/eryone/eryone-pla-silk-azalea-pink-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-azalea-pink-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-azalea-pink-1kg
+class: FFF
+brand_specific_id: B0102466
+url: https://eryone3d.com/products/silk-pla?variant=53969901093230
+material:
+  slug: eryone-pla-silk-azalea-pink
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-blue-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-blue-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-blue-1kg
+class: FFF
+brand_specific_id: B0102005
+url: https://eryone3d.com/products/silk-pla?variant=39267874537521
+material:
+  slug: eryone-pla-silk-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-champagne-pink-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-champagne-pink-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-champagne-pink-1kg
+class: FFF
+brand_specific_id: B0102432
+url: https://eryone3d.com/products/silk-pla?variant=53969900798318
+material:
+  slug: eryone-pla-silk-champagne-pink
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-cherry-pink-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-cherry-pink-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-cherry-pink-1kg
+class: FFF
+brand_specific_id: B0102462
+url: https://eryone3d.com/products/silk-pla?variant=53969900994926
+material:
+  slug: eryone-pla-silk-cherry-pink
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-coffee-gold-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-coffee-gold-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-coffee-gold-1kg
+class: FFF
+brand_specific_id: B0102435
+url: https://eryone3d.com/products/silk-pla?variant=53969900896622
+material:
+  slug: eryone-pla-silk-coffee-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-copper-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-copper-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-copper-1kg
+class: FFF
+brand_specific_id: B0102003
+url: https://eryone3d.com/products/silk-pla?variant=39267874504753
+material:
+  slug: eryone-pla-silk-copper
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dark-green-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dark-green-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dark-green-1kg
+class: FFF
+brand_specific_id: B0102004
+url: https://eryone3d.com/products/silk-pla?variant=39267874570289
+material:
+  slug: eryone-pla-silk-dark-green
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-black-dark-gold-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-black-dark-gold-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-black-dark-gold-1kg
+class: FFF
+brand_specific_id: B0102058
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=43912068432106
+material:
+  slug: eryone-pla-silk-dual-color-black-dark-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-black-dark-green-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-black-dark-green-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-black-dark-green-1kg
+class: FFF
+brand_specific_id: B0102055
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=43879344799978
+material:
+  slug: eryone-pla-silk-dual-color-black-dark-green
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-black-purple-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-black-purple-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-black-purple-1kg
+class: FFF
+brand_specific_id: B0102064
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=43912068464874
+material:
+  slug: eryone-pla-silk-dual-color-black-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-black-red-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-black-red-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-black-red-1kg
+class: FFF
+brand_specific_id: B0102057
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=43912068399338
+material:
+  slug: eryone-pla-silk-dual-color-black-red
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-black-rose-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-black-rose-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-black-rose-1kg
+class: FFF
+brand_specific_id: B0102056
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=43912068366570
+material:
+  slug: eryone-pla-silk-dual-color-black-rose
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-blue-green-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-blue-green-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-blue-green-1kg
+class: FFF
+brand_specific_id: B0102031
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=43100485517546
+material:
+  slug: eryone-pla-silk-dual-color-blue-green
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-blue-green-orange-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-blue-green-orange-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-blue-green-orange-1kg
+class: FFF
+brand_specific_id: B0102270
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=44201716809962
+material:
+  slug: eryone-pla-silk-dual-color-blue-green-orange
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-blue-purple-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-blue-purple-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-blue-purple-1kg
+class: FFF
+brand_specific_id: B0102269
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=44201716875498
+material:
+  slug: eryone-pla-silk-dual-color-blue-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-gold-blue-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-gold-blue-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-gold-blue-1kg
+class: FFF
+brand_specific_id: B0102267
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=44201716842730
+material:
+  slug: eryone-pla-silk-dual-color-gold-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-gold-copper-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-gold-copper-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-gold-copper-1kg
+class: FFF
+brand_specific_id: B0102028
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=43100485615850
+material:
+  slug: eryone-pla-silk-dual-color-gold-copper
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-gold-purple-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-gold-purple-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-gold-purple-1kg
+class: FFF
+brand_specific_id: B0102030
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=43100485550314
+material:
+  slug: eryone-pla-silk-dual-color-gold-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-gold-silver-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-gold-silver-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-gold-silver-1kg
+class: FFF
+brand_specific_id: B0102029
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=43100485583082
+material:
+  slug: eryone-pla-silk-dual-color-gold-silver
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-midnight-blue-black-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-midnight-blue-black-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-midnight-blue-black-1kg
+class: FFF
+brand_specific_id: B0102404
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=52196411638126
+material:
+  slug: eryone-pla-silk-dual-color-midnight-blue-black
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-midnight-blue-silver-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-midnight-blue-silver-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-midnight-blue-silver-1kg
+class: FFF
+brand_specific_id: B0102405
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=52196411670894
+material:
+  slug: eryone-pla-silk-dual-color-midnight-blue-silver
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-orange-blue-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-orange-blue-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-orange-blue-1kg
+class: FFF
+brand_specific_id: B0102407
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=51992770249070
+material:
+  slug: eryone-pla-silk-dual-color-orange-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-purple-green-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-purple-green-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-purple-green-1kg
+class: FFF
+brand_specific_id: B0102268
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=44201716941034
+material:
+  slug: eryone-pla-silk-dual-color-purple-green
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-purple-orange-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-purple-orange-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-purple-orange-1kg
+class: FFF
+brand_specific_id: B0102266
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=44201716908266
+material:
+  slug: eryone-pla-silk-dual-color-purple-orange
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-red-blue-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-red-blue-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-red-blue-1kg
+class: FFF
+brand_specific_id: B0102026
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=43100507701482
+material:
+  slug: eryone-pla-silk-dual-color-red-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-red-gold-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-red-gold-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-red-gold-1kg
+class: FFF
+brand_specific_id: B0102025
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=43100507767018
+material:
+  slug: eryone-pla-silk-dual-color-red-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-red-green-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-red-green-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-red-green-1kg
+class: FFF
+brand_specific_id: B0102027
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=43100485648618
+material:
+  slug: eryone-pla-silk-dual-color-red-green
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-rose-red-light-blue-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-rose-red-light-blue-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-rose-red-light-blue-1kg
+class: FFF
+brand_specific_id: B0102049
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=43912068333802
+material:
+  slug: eryone-pla-silk-dual-color-rose-red-light-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-dual-color-yellow-green-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-dual-color-yellow-green-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-dual-color-yellow-green-1kg
+class: FFF
+brand_specific_id: B0102032
+url: https://eryone3d.com/products/silk-dual-color-pla?variant=43100485484778
+material:
+  slug: eryone-pla-silk-dual-color-yellow-green
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-gold-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-gold-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-gold-1kg
+class: FFF
+brand_specific_id: B0102001
+url: https://eryone3d.com/products/silk-pla?variant=43308783730922
+material:
+  slug: eryone-pla-silk-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-green-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-green-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-green-1kg
+class: FFF
+brand_specific_id: B0102414
+url: https://eryone3d.com/products/silk-pla?variant=52333416808814
+material:
+  slug: eryone-pla-silk-green
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-lake-blue-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-lake-blue-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-lake-blue-1kg
+class: FFF
+brand_specific_id: B0102463
+url: https://eryone3d.com/products/silk-pla?variant=53969901027694
+material:
+  slug: eryone-pla-silk-lake-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-metallic-ceramic-red-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-metallic-ceramic-red-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-metallic-ceramic-red-1kg
+class: FFF
+brand_specific_id: B0102427
+url: https://eryone3d.com/products/silk-pla?variant=53109445591406
+material:
+  slug: eryone-pla-silk-metallic-ceramic-red
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-neon-green-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-neon-green-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-neon-green-1kg
+class: FFF
+brand_specific_id: B0102461
+url: https://eryone3d.com/products/silk-pla?variant=53969900962158
+material:
+  slug: eryone-pla-silk-neon-green
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-orange-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-orange-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-orange-1kg
+class: FFF
+brand_specific_id: B0102460
+url: https://eryone3d.com/products/silk-pla?variant=53969900929390
+material:
+  slug: eryone-pla-silk-orange
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-pale-creamy-yellow-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-pale-creamy-yellow-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-pale-creamy-yellow-1kg
+class: FFF
+brand_specific_id: B0102433
+url: https://eryone3d.com/products/silk-pla?variant=53969900831086
+material:
+  slug: eryone-pla-silk-pale-creamy-yellow
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-pink-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-pink-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-pink-1kg
+class: FFF
+brand_specific_id: B0102006
+url: https://eryone3d.com/products/silk-pla?variant=39267874603057
+material:
+  slug: eryone-pla-silk-pink
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-radiant-gold-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-radiant-gold-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-radiant-gold-1kg
+class: FFF
+brand_specific_id: B0102426
+url: https://eryone3d.com/products/silk-pla?variant=53109445558638
+material:
+  slug: eryone-pla-silk-radiant-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-rose-red-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-rose-red-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-rose-red-1kg
+class: FFF
+brand_specific_id: B0102464
+url: https://eryone3d.com/products/silk-pla?variant=53969901060462
+material:
+  slug: eryone-pla-silk-rose-red
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-royal-blue-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-royal-blue-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-royal-blue-1kg
+class: FFF
+brand_specific_id: B0102430
+url: https://eryone3d.com/products/silk-pla?variant=53969900732782
+material:
+  slug: eryone-pla-silk-royal-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-scarlet-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-scarlet-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-scarlet-1kg
+class: FFF
+brand_specific_id: B0102434
+url: https://eryone3d.com/products/silk-pla?variant=53969900863854
+material:
+  slug: eryone-pla-silk-scarlet
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-silver-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-silver-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-silver-1kg
+class: FFF
+brand_specific_id: B0102002
+url: https://eryone3d.com/products/silk-pla?variant=39267874471985
+material:
+  slug: eryone-pla-silk-silver
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-taro-purple-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-taro-purple-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-taro-purple-1kg
+class: FFF
+brand_specific_id: B0102431
+url: https://eryone3d.com/products/silk-pla?variant=53969900765550
+material:
+  slug: eryone-pla-silk-taro-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-black-blue-purple-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-black-blue-purple-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-black-blue-purple-1kg
+class: FFF
+brand_specific_id: B0102065
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=43912129970410
+material:
+  slug: eryone-pla-silk-triple-color-black-blue-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-black-gold-purple-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-black-gold-purple-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-black-gold-purple-1kg
+class: FFF
+brand_specific_id: B0102063
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=43912129937642
+material:
+  slug: eryone-pla-silk-triple-color-black-gold-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-black-red-gold-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-black-red-gold-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-black-red-gold-1kg
+class: FFF
+brand_specific_id: B0102062
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=43912129904874
+material:
+  slug: eryone-pla-silk-triple-color-black-red-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-dark-green-midnight-blue-black-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-dark-green-midnight-blue-black-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-dark-green-midnight-blue-black-1kg
+class: FFF
+brand_specific_id: B0102408
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=51992762909038
+material:
+  slug: eryone-pla-silk-triple-color-dark-green-midnight-blue-black
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-dark-green-purple-yellow-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-dark-green-purple-yellow-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-dark-green-purple-yellow-1kg
+class: FFF
+brand_specific_id: B0102233
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=44197238735082
+material:
+  slug: eryone-pla-silk-triple-color-dark-green-purple-yellow
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-gold-blue-purple-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-gold-blue-purple-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-gold-blue-purple-1kg
+class: FFF
+brand_specific_id: B0102241
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=44357735874794
+material:
+  slug: eryone-pla-silk-triple-color-gold-blue-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-gold-green-purple-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-gold-green-purple-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-gold-green-purple-1kg
+class: FFF
+brand_specific_id: B0102238
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=44357735907562
+material:
+  slug: eryone-pla-silk-triple-color-gold-green-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-gold-silver-copper-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-gold-silver-copper-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-gold-silver-copper-1kg
+class: FFF
+brand_specific_id: B0102041
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=43405848576234
+material:
+  slug: eryone-pla-silk-triple-color-gold-silver-copper
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-orange-blue-green-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-orange-blue-green-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-orange-blue-green-1kg
+class: FFF
+brand_specific_id: B0102036
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=43405848674538
+material:
+  slug: eryone-pla-silk-triple-color-orange-blue-green
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-purple-teal-burnt-orange-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-purple-teal-burnt-orange-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-purple-teal-burnt-orange-1kg
+class: FFF
+brand_specific_id: B0102277
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=44197238833386
+material:
+  slug: eryone-pla-silk-triple-color-purple-teal-burnt-orange
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-red-blue-green-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-red-blue-green-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-red-blue-green-1kg
+class: FFF
+brand_specific_id: B0102039
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=43405848609002
+material:
+  slug: eryone-pla-silk-triple-color-red-blue-green
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-red-gold-purple-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-red-gold-purple-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-red-gold-purple-1kg
+class: FFF
+brand_specific_id: B0102038
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=43405848641770
+material:
+  slug: eryone-pla-silk-triple-color-red-gold-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-red-purple-green-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-red-purple-green-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-red-purple-green-1kg
+class: FFF
+brand_specific_id: B0102234
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=44197238767850
+material:
+  slug: eryone-pla-silk-triple-color-red-purple-green
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-red-yellow-blue-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-red-yellow-blue-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-red-yellow-blue-1kg
+class: FFF
+brand_specific_id: B0102037
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=43405848707306
+material:
+  slug: eryone-pla-silk-triple-color-red-yellow-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-sapphire-green-orange-red-gold-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-sapphire-green-orange-red-gold-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-sapphire-green-orange-red-gold-1kg
+class: FFF
+brand_specific_id: B0102276
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=44197238800618
+material:
+  slug: eryone-pla-silk-triple-color-sapphire-green-orange-red-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-twisted-rainbow-fantasy-red-gold-blue-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-twisted-rainbow-fantasy-red-gold-blue-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-twisted-rainbow-fantasy-red-gold-blue-1kg
+class: FFF
+brand_specific_id: B0103069
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=52157010870638
+material:
+  slug: eryone-pla-silk-triple-color-twisted-rainbow-fantasy-red-gold-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-twisted-rainbow-fire-red-gold-purple-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-twisted-rainbow-fire-red-gold-purple-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-twisted-rainbow-fire-red-gold-purple-1kg
+class: FFF
+brand_specific_id: B0103052
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=51673809518958
+material:
+  slug: eryone-pla-silk-triple-color-twisted-rainbow-fire-red-gold-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-twisted-rainbow-psychedelic-red-yellow-blue-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-twisted-rainbow-psychedelic-red-yellow-blue-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-twisted-rainbow-psychedelic-red-yellow-blue-1kg
+class: FFF
+brand_specific_id: B0103054
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=51673809584494
+material:
+  slug: eryone-pla-silk-triple-color-twisted-rainbow-psychedelic-red-yellow-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-twisted-rainbow-shadow-black-blue-purple-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-twisted-rainbow-shadow-black-blue-purple-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-twisted-rainbow-shadow-black-blue-purple-1kg
+class: FFF
+brand_specific_id: B0103053
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=51673809551726
+material:
+  slug: eryone-pla-silk-triple-color-twisted-rainbow-shadow-black-blue-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-triple-color-twisted-rainbow-tracing-red-blue-green-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-triple-color-twisted-rainbow-tracing-red-blue-green-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-triple-color-twisted-rainbow-tracing-red-blue-green-1kg
+class: FFF
+brand_specific_id: B0103055
+url: https://eryone3d.com/products/pla-silk-triple-color-filament?variant=51673809617262
+material:
+  slug: eryone-pla-silk-triple-color-twisted-rainbow-tracing-red-blue-green
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/material-packages/eryone/eryone-pla-silk-white-1kg.yaml
+++ b/data/material-packages/eryone/eryone-pla-silk-white-1kg.yaml
@@ -1,0 +1,11 @@
+slug: eryone-pla-silk-white-1kg
+class: FFF
+brand_specific_id: B0102007
+url: https://eryone3d.com/products/silk-pla?variant=39267874439217
+material:
+  slug: eryone-pla-silk-white
+nominal_netto_full_weight: 1000
+container:
+  slug: eryone-cardboard-spool-1kg
+filament_diameter: 1750
+filament_diameter_tolerance: 30

--- a/data/materials/eryone/eryone-pla-silk-azalea-pink.yaml
+++ b/data/materials/eryone/eryone-pla-silk-azalea-pink.yaml
@@ -1,0 +1,21 @@
+uuid: 55704276-758d-5bc8-8e93-08c5bc629f48
+slug: eryone-pla-silk-azalea-pink
+brand:
+  slug: eryone
+name: PLA Silk Azalea Pink
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/1-800_4de8aed5-d351-40c6-bb0d-c741e6b216f2.jpg?v=1781737926
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-blue.yaml
+++ b/data/materials/eryone/eryone-pla-silk-blue.yaml
@@ -1,0 +1,23 @@
+uuid: bf4d4050-45f1-58ab-a05e-82bf60105d9d
+slug: eryone-pla-silk-blue
+brand:
+  slug: eryone
+name: PLA Silk Blue
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#62a9d3ff'
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Filament-2.jpg?v=1767680110
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-champagne-pink.yaml
+++ b/data/materials/eryone/eryone-pla-silk-champagne-pink.yaml
@@ -1,0 +1,21 @@
+uuid: 4062c112-2a3b-549a-865f-37fe2013ab6e
+slug: eryone-pla-silk-champagne-pink
+brand:
+  slug: eryone
+name: PLA Silk Champagne Pink
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/B0102432.jpg?v=1781686707
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-cherry-pink.yaml
+++ b/data/materials/eryone/eryone-pla-silk-cherry-pink.yaml
@@ -1,0 +1,21 @@
+uuid: e12ca303-7d53-5267-a4ba-a57a4ebfd8e2
+slug: eryone-pla-silk-cherry-pink
+brand:
+  slug: eryone
+name: PLA Silk Cherry Pink
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/1-800_c8783cdd-3ba3-4658-a411-e362e26beff4.jpg?v=1781737868
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-coffee-gold.yaml
+++ b/data/materials/eryone/eryone-pla-silk-coffee-gold.yaml
@@ -1,0 +1,23 @@
+uuid: b7671004-9af8-518a-95a4-b7cfce600c3f
+slug: eryone-pla-silk-coffee-gold
+brand:
+  slug: eryone
+name: PLA Silk Coffee Gold
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#cc947bff'
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/B0102435.jpg?v=1781686729
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-copper.yaml
+++ b/data/materials/eryone/eryone-pla-silk-copper.yaml
@@ -1,0 +1,23 @@
+uuid: 06b75510-e422-5c55-bf33-1bd8f47694db
+slug: eryone-pla-silk-copper
+brand:
+  slug: eryone
+name: PLA Silk Copper
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#b36a50ff'
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Filament-3.jpg?v=1767680110
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dark-green.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dark-green.yaml
@@ -1,0 +1,21 @@
+uuid: 852c8b00-0268-5f31-8bab-a2aa4663bc90
+slug: eryone-pla-silk-dark-green
+brand:
+  slug: eryone
+name: PLA Silk Dark Green
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Filament-4.jpg?v=1767680110
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-black-dark-gold.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-black-dark-gold.yaml
@@ -1,0 +1,22 @@
+uuid: 0e7a541d-e8b0-51e1-a8e5-d497adf3cadb
+slug: eryone-pla-silk-dual-color-black-dark-gold
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Black Dark Gold
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/products/PLA-Silk-Dual-Color-Filament-2.jpg?v=1772430910
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-black-dark-green.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-black-dark-green.yaml
@@ -1,0 +1,22 @@
+uuid: 1f729349-b553-553e-985d-731506ac72f0
+slug: eryone-pla-silk-dual-color-black-dark-green
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Black Dark Green
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/products/PLA-Silk-Dual-Color-Filament-8.jpg?v=1772430910
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-black-purple.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-black-purple.yaml
@@ -1,0 +1,25 @@
+uuid: b83857d9-99b5-5dea-8f4e-517b5a49e455
+slug: eryone-pla-silk-dual-color-black-purple
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Black Purple
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#000000ff'
+- color_rgba: '#7a4da8ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/products/PLA-Silk-Dual-Color-Filament-9.jpg?v=1774937074
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-black-red.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-black-red.yaml
@@ -1,0 +1,25 @@
+uuid: 66fa4e0f-67cd-5d7b-ae7c-222380575735
+slug: eryone-pla-silk-dual-color-black-red
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Black Red
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#000000ff'
+- color_rgba: '#700000ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/products/PLA-Silk-Dual-Color-Filament-1.jpg?v=1774937074
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-black-rose.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-black-rose.yaml
@@ -1,0 +1,25 @@
+uuid: e99ed6f6-a0dc-5b87-9d76-7775438630da
+slug: eryone-pla-silk-dual-color-black-rose
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Black Rose
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#000000ff'
+- color_rgba: '#57001eff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/products/PLA-Silk-Dual-Color-Filament-14.jpg?v=1776650678
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-blue-green-orange.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-blue-green-orange.yaml
@@ -1,0 +1,22 @@
+uuid: 73e7366c-785c-5ad9-ba32-3ef7dcb88a4f
+slug: eryone-pla-silk-dual-color-blue-green-orange
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Blue Green Orange
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Dual-Color-Filament-13.jpg?v=1774937074
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-blue-green.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-blue-green.yaml
@@ -1,0 +1,25 @@
+uuid: cf383ad0-db29-5e6a-bf2e-9cc5b20bf69c
+slug: eryone-pla-silk-dual-color-blue-green
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Blue Green
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#01509dff'
+- color_rgba: '#019f55ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-2-Color-Filament-6.png?v=1772430910
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-blue-purple.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-blue-purple.yaml
@@ -1,0 +1,25 @@
+uuid: 7cf0d4f3-c52c-566a-ab77-4cb75732ccd5
+slug: eryone-pla-silk-dual-color-blue-purple
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Blue Purple
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#004cffff'
+- color_rgba: '#9900ffff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-2-Color-Filament-7.jpg?v=1772430910
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-gold-blue.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-gold-blue.yaml
@@ -1,0 +1,22 @@
+uuid: 32943651-fdbd-5297-87de-262f6e6c3988
+slug: eryone-pla-silk-dual-color-gold-blue
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Gold Blue
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Dual-Color-Filament-11.jpg?v=1772430910
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-gold-copper.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-gold-copper.yaml
@@ -1,0 +1,25 @@
+uuid: 0199cb41-59b3-5fbe-a9cc-261c889dc3f6
+slug: eryone-pla-silk-dual-color-gold-copper
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Gold Copper
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#d5983aff'
+- color_rgba: '#a84815ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Dual-Color-Filament-23.png?v=1772430910
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-gold-purple.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-gold-purple.yaml
@@ -1,0 +1,25 @@
+uuid: 33bcc985-bfac-5cc0-9d90-638653c51eb3
+slug: eryone-pla-silk-dual-color-gold-purple
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Gold Purple
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#e5bf3aff'
+- color_rgba: '#c23fbfff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Dual-Color-Filament-25.png?v=1776650678
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-gold-silver.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-gold-silver.yaml
@@ -1,0 +1,25 @@
+uuid: a6a4c75e-099d-5702-ad80-1564887eea24
+slug: eryone-pla-silk-dual-color-gold-silver
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Gold Silver
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#d5983aff'
+- color_rgba: '#999ba6ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Dual-Color-Filament-25.jpg?v=1772430910
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-midnight-blue-black.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-midnight-blue-black.yaml
@@ -1,0 +1,25 @@
+uuid: 0d95760c-508f-554f-85ab-3b3a039e7a36
+slug: eryone-pla-silk-dual-color-midnight-blue-black
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Midnight Blue Black
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#0000ffff'
+- color_rgba: '#000000ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/7829c60bb0ab67a17fd25b0179f6005b.jpg?v=1751423239
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-midnight-blue-silver.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-midnight-blue-silver.yaml
@@ -1,0 +1,25 @@
+uuid: 222d9a8c-a434-5632-901b-6223e37316cd
+slug: eryone-pla-silk-dual-color-midnight-blue-silver
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Midnight Blue Silver
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#191970ff'
+- color_rgba: '#c0c0c0ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/e6dab045ef4a307322ce76a737affbf7.jpg?v=1751479819
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-orange-blue.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-orange-blue.yaml
@@ -1,0 +1,25 @@
+uuid: 0107999e-ced3-5a6a-9cc2-537ec49f96da
+slug: eryone-pla-silk-dual-color-orange-blue
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Orange Blue
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#c37c64ff'
+- color_rgba: '#5d99f7ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-2-Color-Filament-5.jpg?v=1772430910
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-purple-green.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-purple-green.yaml
@@ -1,0 +1,25 @@
+uuid: 3e6f060a-2260-5545-ab80-bb0461139c53
+slug: eryone-pla-silk-dual-color-purple-green
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Purple Green
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#662e85ff'
+- color_rgba: '#209734ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Dual-Color-Filament-15.jpg?v=1772430910
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-purple-orange.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-purple-orange.yaml
@@ -1,0 +1,22 @@
+uuid: bc89cb6c-45a9-5c69-b2a4-76bd64b9c0b6
+slug: eryone-pla-silk-dual-color-purple-orange
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Purple Orange
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Dual-Color-Filament-12.jpg?v=1774937074
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-red-blue.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-red-blue.yaml
@@ -1,0 +1,25 @@
+uuid: 85a29625-e44d-5e55-8df4-1c7c8f39ba30
+slug: eryone-pla-silk-dual-color-red-blue
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Red Blue
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#e91620ff'
+- color_rgba: '#1639e3ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Dual-Color-Filament-6.png?v=1776650678
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-red-gold.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-red-gold.yaml
@@ -1,0 +1,25 @@
+uuid: b091b7a2-1b13-54e2-a791-663addcb1bbc
+slug: eryone-pla-silk-dual-color-red-gold
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Red Gold
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#d20f0fff'
+- color_rgba: '#d5983aff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Dual-Color-Filament-22.jpg?v=1772430910
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-red-green.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-red-green.yaml
@@ -1,0 +1,25 @@
+uuid: c43cae33-9ac8-5637-b38f-05c626f89084
+slug: eryone-pla-silk-dual-color-red-green
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Red Green
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#fa0000ff'
+- color_rgba: '#0b6a16ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Dual-Color-Filament-7.jpg?v=1772430910
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-rose-red-light-blue.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-rose-red-light-blue.yaml
@@ -1,0 +1,25 @@
+uuid: 12dd37f9-554d-5eaf-862f-1526c21f1db0
+slug: eryone-pla-silk-dual-color-rose-red-light-blue
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Rose Red Light Blue
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#d864c7ff'
+- color_rgba: '#779bf9ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/products/PLA-Silk-2-Color-Filament-9.jpg?v=1772430910
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-dual-color-yellow-green.yaml
+++ b/data/materials/eryone/eryone-pla-silk-dual-color-yellow-green.yaml
@@ -1,0 +1,25 @@
+uuid: f6ebd2fb-c4e7-5884-97bb-0594c864e8c2
+slug: eryone-pla-silk-dual-color-yellow-green
+brand:
+  slug: eryone
+name: PLA Silk Dual-Color Yellow Green
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#f9f06bff'
+- color_rgba: '#a6e548ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Dual-Color-Filament-24.png?v=1772430910
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-gold.yaml
+++ b/data/materials/eryone/eryone-pla-silk-gold.yaml
@@ -1,0 +1,21 @@
+uuid: 0c30b10d-6acf-509f-aee2-4f88e3120045
+slug: eryone-pla-silk-gold
+brand:
+  slug: eryone
+name: PLA Silk Gold
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Filament-1.jpg?v=1767680110
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-green.yaml
+++ b/data/materials/eryone/eryone-pla-silk-green.yaml
@@ -1,0 +1,21 @@
+uuid: 136493e5-8e01-5b5a-b59e-ec267833c590
+slug: eryone-pla-silk-green
+brand:
+  slug: eryone
+name: PLA Silk Green
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/1-800.png?v=1767680110
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-lake-blue.yaml
+++ b/data/materials/eryone/eryone-pla-silk-lake-blue.yaml
@@ -1,0 +1,21 @@
+uuid: cdaa7663-df2a-57da-9a52-795eb45b713d
+slug: eryone-pla-silk-lake-blue
+brand:
+  slug: eryone
+name: PLA Silk Lake Blue
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/1-800_d4a785cf-ce39-4a2b-be1c-607754e83154.jpg?v=1781737868
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-metallic-ceramic-red.yaml
+++ b/data/materials/eryone/eryone-pla-silk-metallic-ceramic-red.yaml
@@ -1,0 +1,21 @@
+uuid: 52c126b4-37bb-5ece-932a-3b428a70a79e
+slug: eryone-pla-silk-metallic-ceramic-red
+brand:
+  slug: eryone
+name: PLA Silk Metallic Ceramic Red
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/1-1-800.png?v=1766407146
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-neon-green.yaml
+++ b/data/materials/eryone/eryone-pla-silk-neon-green.yaml
@@ -1,0 +1,21 @@
+uuid: 80c54a47-b9e2-53e4-a9c8-b68768d35b95
+slug: eryone-pla-silk-neon-green
+brand:
+  slug: eryone
+name: PLA Silk Neon Green
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/1-800_bd37780e-2677-475d-b4ae-d3d602b7be8b.jpg?v=1781737868
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-orange.yaml
+++ b/data/materials/eryone/eryone-pla-silk-orange.yaml
@@ -1,0 +1,21 @@
+uuid: 63ecdf0c-7809-5d6e-996c-71119096c5e6
+slug: eryone-pla-silk-orange
+brand:
+  slug: eryone
+name: PLA Silk Orange
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/1-800_20df263b-f46f-427a-9e85-40708fd40cf0.jpg?v=1781737868
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-pale-creamy-yellow.yaml
+++ b/data/materials/eryone/eryone-pla-silk-pale-creamy-yellow.yaml
@@ -1,0 +1,21 @@
+uuid: 276577b4-c1b2-54d8-a68e-b86bbdf119d7
+slug: eryone-pla-silk-pale-creamy-yellow
+brand:
+  slug: eryone
+name: PLA Silk Pale Creamy Yellow
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/B0102433.jpg?v=1781686714
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-pink.yaml
+++ b/data/materials/eryone/eryone-pla-silk-pink.yaml
@@ -1,0 +1,23 @@
+uuid: c4842c06-063b-57d0-8f45-1673bd6d7b9f
+slug: eryone-pla-silk-pink
+brand:
+  slug: eryone
+name: PLA Silk Pink
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#ff40ffff'
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Filament-5.jpg?v=1767680110
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-radiant-gold.yaml
+++ b/data/materials/eryone/eryone-pla-silk-radiant-gold.yaml
@@ -1,0 +1,21 @@
+uuid: 0c3bea09-6f7e-59d0-a36f-5ca17a86a217
+slug: eryone-pla-silk-radiant-gold
+brand:
+  slug: eryone
+name: PLA Silk Radiant Gold
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/1-800_e1ee7852-8eef-45dc-9f4c-3bc53723fe95.png?v=1770000845
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-rose-red.yaml
+++ b/data/materials/eryone/eryone-pla-silk-rose-red.yaml
@@ -1,0 +1,21 @@
+uuid: 1cdfe971-960b-5319-b666-3a73bc857648
+slug: eryone-pla-silk-rose-red
+brand:
+  slug: eryone
+name: PLA Silk Rose Red
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/1-800_7a890c21-0f59-43db-ad25-b787db649155.jpg?v=1781737926
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-royal-blue.yaml
+++ b/data/materials/eryone/eryone-pla-silk-royal-blue.yaml
@@ -1,0 +1,21 @@
+uuid: 7c00f1bd-cca4-5ed8-9d54-fd7e66740899
+slug: eryone-pla-silk-royal-blue
+brand:
+  slug: eryone
+name: PLA Silk Royal Blue
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/B0102430.jpg?v=1781737868
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-scarlet.yaml
+++ b/data/materials/eryone/eryone-pla-silk-scarlet.yaml
@@ -1,0 +1,21 @@
+uuid: 8364eba7-1ab1-5b16-b577-6a85795bf304
+slug: eryone-pla-silk-scarlet
+brand:
+  slug: eryone
+name: PLA Silk Scarlet
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/B0102434.jpg?v=1781686723
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-silver.yaml
+++ b/data/materials/eryone/eryone-pla-silk-silver.yaml
@@ -1,0 +1,23 @@
+uuid: 11c9abb6-f6f9-5ca8-a429-e8b16c5646e6
+slug: eryone-pla-silk-silver
+brand:
+  slug: eryone
+name: PLA Silk Silver
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#999ba6ff'
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Filament-7.jpg?v=1767680071
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-taro-purple.yaml
+++ b/data/materials/eryone/eryone-pla-silk-taro-purple.yaml
@@ -1,0 +1,21 @@
+uuid: 8aa25963-22c3-5fba-afa7-dc166ce1a578
+slug: eryone-pla-silk-taro-purple
+brand:
+  slug: eryone
+name: PLA Silk Taro Purple
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/B0102431.jpg?v=1781686700
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-black-blue-purple.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-black-blue-purple.yaml
@@ -1,0 +1,26 @@
+uuid: 8b7019ec-c53f-5b3b-a501-790895329eb2
+slug: eryone-pla-silk-triple-color-black-blue-purple
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Black Blue Purple
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#000000ff'
+- color_rgba: '#0420f6ff'
+- color_rgba: '#7304fbff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA_Silk_Triple-Color_Filament_-_1.75mm-3.jpg?v=1776650739
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-black-gold-purple.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-black-gold-purple.yaml
@@ -1,0 +1,26 @@
+uuid: 7a71c988-bdad-5cba-ba46-3e5d2b234160
+slug: eryone-pla-silk-triple-color-black-gold-purple
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Black Gold Purple
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#000000ff'
+- color_rgba: '#ffed5bff'
+- color_rgba: '#45266aff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/best-pla-Filament-30.jpg?v=1770105710
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-black-red-gold.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-black-red-gold.yaml
@@ -1,0 +1,26 @@
+uuid: 57ee4bfd-489f-5626-a45f-659a3190e2c3
+slug: eryone-pla-silk-triple-color-black-red-gold
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Black Red Gold
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#000000ff'
+- color_rgba: '#d92b44ff'
+- color_rgba: '#cd8401ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/best-pla-Filament-29.jpg?v=1770105710
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-dark-green-midnight-blue-black.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-dark-green-midnight-blue-black.yaml
@@ -1,0 +1,22 @@
+uuid: 71bd7a8c-af9e-5443-b552-b50243d941b4
+slug: eryone-pla-silk-triple-color-dark-green-midnight-blue-black
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Dark Green Midnight Blue Black
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA_Silk_Triple-Color_Filament.jpg?v=1770105710
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-dark-green-purple-yellow.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-dark-green-purple-yellow.yaml
@@ -1,0 +1,22 @@
+uuid: e508ab0d-30da-5bc1-93c6-46490d0c781d
+slug: eryone-pla-silk-triple-color-dark-green-purple-yellow
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Dark Green Purple Yellow
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/3d-filament-pla-Dark_green_Purple_Yellow.jpg?v=1774937086
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-gold-blue-purple.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-gold-blue-purple.yaml
@@ -1,0 +1,26 @@
+uuid: 842d6e3a-8bfa-5d21-8b5c-437435c6b487
+slug: eryone-pla-silk-triple-color-gold-blue-purple
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Gold Blue Purple
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#fffb40ff'
+- color_rgba: '#0140c1ff'
+- color_rgba: '#821ac5ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/3d-filament-pla-Gold_Blue_Purple.jpg?v=1773193092
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-gold-green-purple.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-gold-green-purple.yaml
@@ -1,0 +1,26 @@
+uuid: 207dd142-91e3-56c7-81ab-deba122ad874
+slug: eryone-pla-silk-triple-color-gold-green-purple
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Gold Green Purple
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#b6a91bff'
+- color_rgba: '#25d30dff'
+- color_rgba: '#4f3aeeff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/3d-filament-pla-Gold_Green_Purple.jpg?v=1755140467
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-gold-silver-copper.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-gold-silver-copper.yaml
@@ -1,0 +1,22 @@
+uuid: bd8f8866-2de8-5d5f-8d8b-b4d76211289a
+slug: eryone-pla-silk-triple-color-gold-silver-copper
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Gold Silver Copper
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/best-pla-Filament-24.jpg?v=1753509322
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-orange-blue-green.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-orange-blue-green.yaml
@@ -1,0 +1,22 @@
+uuid: 0a3bd108-fd92-5651-a260-4c2dbbb042ee
+slug: eryone-pla-silk-triple-color-orange-blue-green
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Orange Blue Green
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/best-pla-Filament-27.jpg?v=1770105710
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-purple-teal-burnt-orange.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-purple-teal-burnt-orange.yaml
@@ -1,0 +1,26 @@
+uuid: 1b79ebe3-1bd6-5aa7-badd-254953a7a768
+slug: eryone-pla-silk-triple-color-purple-teal-burnt-orange
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Purple Teal Burnt Orange
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#611987ff'
+- color_rgba: '#019096ff'
+- color_rgba: '#cf5e24ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/3d-filament-pla-Purple_Teal_Burnt_Orange.jpg?v=1776650739
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-red-blue-green.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-red-blue-green.yaml
@@ -1,0 +1,26 @@
+uuid: 2140b519-28f0-526d-9b3f-44ac251fbdfa
+slug: eryone-pla-silk-triple-color-red-blue-green
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Red Blue Green
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#e25ba5ff'
+- color_rgba: '#413feeff'
+- color_rgba: '#76cb64ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/best-pla-Filament-25.jpg?v=1773193092
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-red-gold-purple.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-red-gold-purple.yaml
@@ -1,0 +1,26 @@
+uuid: fd79d24a-b51c-5d33-aa9b-47f064be210e
+slug: eryone-pla-silk-triple-color-red-gold-purple
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Red Gold Purple
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#ff0000ff'
+- color_rgba: '#ffd700ff'
+- color_rgba: '#800080ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/best-pla-Filament-26.jpg?v=1770105710
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-red-purple-green.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-red-purple-green.yaml
@@ -1,0 +1,26 @@
+uuid: 55cb5ab7-7aa7-5fba-a7cc-9a101850fc3e
+slug: eryone-pla-silk-triple-color-red-purple-green
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Red Purple Green
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#ff0000ff'
+- color_rgba: '#8c15b7ff'
+- color_rgba: '#1dfa00ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/3d-filament-pla-65.jpg?v=1774937086
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-red-yellow-blue.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-red-yellow-blue.yaml
@@ -1,0 +1,26 @@
+uuid: 109d7050-415e-51b7-9d41-07d969a4e67b
+slug: eryone-pla-silk-triple-color-red-yellow-blue
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Red Yellow Blue
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#ea396dff'
+- color_rgba: '#fff786ff'
+- color_rgba: '#313af7ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA_Silk_Triple-Color_Filament_-_1.75mm-RED_YELLOW_BLUE.jpg?v=1776650739
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-sapphire-green-orange-red-gold.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-sapphire-green-orange-red-gold.yaml
@@ -1,0 +1,26 @@
+uuid: 7b989d3f-3baa-59ce-8592-2d7ff36dc317
+slug: eryone-pla-silk-triple-color-sapphire-green-orange-red-gold
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Sapphire Green Orange Red Gold
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#4dbc9bff'
+- color_rgba: '#f690d2ff'
+- color_rgba: '#fcbf40ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/3d-filament-pla-3.jpg?v=1774937086
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-twisted-rainbow-fantasy-red-gold-blue.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-twisted-rainbow-fantasy-red-gold-blue.yaml
@@ -1,0 +1,22 @@
+uuid: 55440a66-1696-5371-a204-519594ec3082
+slug: eryone-pla-silk-triple-color-twisted-rainbow-fantasy-red-gold-blue
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Twisted Rainbow Fantasy Red Gold Blue
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA_Silk_Triple-Color_Filament_-_1.75mm-2.jpg?v=1770105710
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-twisted-rainbow-fire-red-gold-purple.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-twisted-rainbow-fire-red-gold-purple.yaml
@@ -1,0 +1,22 @@
+uuid: 882c8271-037c-5edc-b9f5-8dbbcea331e5
+slug: eryone-pla-silk-triple-color-twisted-rainbow-fire-red-gold-purple
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Twisted Rainbow Fire Red Gold Purple
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/3d-filament-pla-5.jpg?v=1770105710
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-twisted-rainbow-psychedelic-red-yellow-blue.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-twisted-rainbow-psychedelic-red-yellow-blue.yaml
@@ -1,0 +1,22 @@
+uuid: 82603dbc-60e2-528b-8bed-491d1eeff4fc
+slug: eryone-pla-silk-triple-color-twisted-rainbow-psychedelic-red-yellow-blue
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Twisted Rainbow Psychedelic Red Yellow Blue
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/3d-filament-pla-1.jpg?v=1776650739
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-twisted-rainbow-shadow-black-blue-purple.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-twisted-rainbow-shadow-black-blue-purple.yaml
@@ -1,0 +1,22 @@
+uuid: 7b8db870-f61d-5c05-8f28-0e345f867c4b
+slug: eryone-pla-silk-triple-color-twisted-rainbow-shadow-black-blue-purple
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Twisted Rainbow Shadow Black Blue Purple
+class: FFF
+type: PLA
+abbreviation: PLA
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/3d-filament-pla-4.jpg?v=1770105710
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-triple-color-twisted-rainbow-tracing-red-blue-green.yaml
+++ b/data/materials/eryone/eryone-pla-silk-triple-color-twisted-rainbow-tracing-red-blue-green.yaml
@@ -1,0 +1,26 @@
+uuid: d78887df-2a84-5240-b5f6-a2f39047b663
+slug: eryone-pla-silk-triple-color-twisted-rainbow-tracing-red-blue-green
+brand:
+  slug: eryone
+name: PLA Silk Triple-Color Twisted Rainbow Tracing Red Blue Green
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#dc4669ff'
+- color_rgba: '#0456bbff'
+- color_rgba: '#1b6444ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA_Silk_Triple-Color_Filament_-_1.75mm-1.jpg?v=1770105710
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/eryone/eryone-pla-silk-white.yaml
+++ b/data/materials/eryone/eryone-pla-silk-white.yaml
@@ -1,0 +1,23 @@
+uuid: 39345830-507b-57bf-85fd-18bd6b7513a0
+slug: eryone-pla-silk-white
+brand:
+  slug: eryone
+name: PLA Silk White
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#ffffffff'
+tags:
+- silk
+photos:
+- url: https://cdn.shopify.com/s/files/1/0252/0412/9841/files/PLA-Silk-Filament-6.jpg?v=1770000845
+  type: unspecified
+properties:
+  density: 1.32
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 55
+  max_bed_temperature: 70
+  drying_temperature: 55
+  drying_time: 480


### PR DESCRIPTION
Adds Eryone's standard PLA Silk lines — single-color, dual-color, and triple-color —
  as new materials with specs and 1kg packages, plus the Eryone cardboard spool container.

  ### Materials (64, new)
  - **PLA Silk** (single-color) — 22 colors
  - **PLA Silk Dual-Color** (co-extruded) — 22 colors
  - **PLA Silk Triple-Color** (co-extruded) — 20 colors
  - Properties from Eryone's TDS (shared across the standard silk lines):
    nozzle 190–220 °C, bed 55–70 °C, drying 55 °C / 8 h, density 1.32 g/cm³, 1.75 mm
  - Per-color photos (manufacturer CDN). Datasheet values with no schema field
    (Vicat, HDT, Tg, melt index, mechanicals, print speed) are omitted.
  - Tags: `silk` (single), `silk` + `coextruded` (dual/triple).
  - Some colors are recorded without a hex for now (color is optional); they carry
    photo + specs + package and can be backfilled later.
    
  ### Container (1, new)
  - `eryone-cardboard-spool-1kg` — cardboard, hole 57 / outer 200 / width 64 mm, empty 156 g

  ### Packages (64, new)
  - `eryone-pla-silk-*-1kg`, 1000 g, 1.75 mm (±0.03 → tolerance 30), on the cardboard spool
  - `brand_specific_id` = Eryone SKU; variant product URL on the package
  - GTIN-less (no barcodes on the listing) — backfillable later
  
  Source: https://eryone3d.com/collections/pla-silk-all
  `make validate` passes; README/manifest untouched.