### PR TITLE
Add specs and 1kg packages for ELEGOO ASA line

### DIFF
--- a/data/material-packages/elegoo/elegoo-asa-black-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-asa-black-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-asa-black-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3DF-AS0708B
+url: https://us.elegoo.com/products/asa-filament-1-75mm-colored-1kg?variant=43734194651317
+material:
+  slug: elegoo-asa-black
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-asa-blue-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-asa-blue-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-asa-blue-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3DF-AS0732
+url: https://us.elegoo.com/products/asa-filament-1-75mm-colored-1kg?variant=51729604739253
+material:
+  slug: elegoo-asa-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-asa-green-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-asa-green-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-asa-green-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3DF-AS0733
+url: https://us.elegoo.com/products/asa-filament-1-75mm-colored-1kg?variant=51729608114357
+material:
+  slug: elegoo-asa-green
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-asa-grey-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-asa-grey-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-asa-grey-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3DF-AS0738
+url: https://us.elegoo.com/products/asa-filament-1-75mm-colored-1kg?variant=51729608147125
+material:
+  slug: elegoo-asa-grey
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-asa-red-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-asa-red-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-asa-red-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3DF-AS0739
+url: https://us.elegoo.com/products/asa-filament-1-75mm-colored-1kg?variant=51729608179893
+material:
+  slug: elegoo-asa-red
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-asa-white-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-asa-white-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-asa-white-1kg
+class: FFF
+brand_specific_id: SPUS-EL-3DF-AS0709
+url: https://us.elegoo.com/products/asa-filament-1-75mm-colored-1kg?variant=43734194684085
+material:
+  slug: elegoo-asa-white
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/materials/elegoo/elegoo-asa-blue.yaml
+++ b/data/materials/elegoo/elegoo-asa-blue.yaml
@@ -1,15 +1,15 @@
-uuid: 3738cd07-d915-57b5-8f66-fc131e9b01c8
-slug: elegoo-asa-black
+uuid: 2e4e1361-a760-5757-8a22-43da47a82d02
+slug: elegoo-asa-blue
 brand:
   slug: elegoo
-name: ASA Black
+name: ASA Blue
 class: FFF
 type: ASA
 abbreviation: ASA
 primary_color:
-  color_rgba: '#000000ff'
+  color_rgba: '#0c2388ff'
 photos:
-- url: https://files.openprinttag.org/elegoo/elegoo-asa-black/130e85b202c5.png
+- url: https://cdn.shopify.com/s/files/1/0639/7660/3829/files/ASA_1KG_1.75mm_784848d6-e69f-421e-9354-61cda2822ec0.jpg?v=1769592863
   type: unspecified
 properties:
   density: 1.09

--- a/data/materials/elegoo/elegoo-asa-green.yaml
+++ b/data/materials/elegoo/elegoo-asa-green.yaml
@@ -1,15 +1,13 @@
-uuid: 3738cd07-d915-57b5-8f66-fc131e9b01c8
-slug: elegoo-asa-black
+uuid: 419112b3-fcda-5f15-adc1-717d0466a20d
+slug: elegoo-asa-green
 brand:
   slug: elegoo
-name: ASA Black
+name: ASA Green
 class: FFF
 type: ASA
 abbreviation: ASA
-primary_color:
-  color_rgba: '#000000ff'
 photos:
-- url: https://files.openprinttag.org/elegoo/elegoo-asa-black/130e85b202c5.png
+- url: https://cdn.shopify.com/s/files/1/0639/7660/3829/files/ASA_1KG_1.75mm_d429d357-8fdb-458a-a46e-a0e745c1ce21.jpg?v=1769592863
   type: unspecified
 properties:
   density: 1.09

--- a/data/materials/elegoo/elegoo-asa-grey.yaml
+++ b/data/materials/elegoo/elegoo-asa-grey.yaml
@@ -1,15 +1,15 @@
-uuid: 3738cd07-d915-57b5-8f66-fc131e9b01c8
-slug: elegoo-asa-black
+uuid: f0ed0a06-eef5-5bb7-b69a-d3bccbbf7a7f
+slug: elegoo-asa-grey
 brand:
   slug: elegoo
-name: ASA Black
+name: ASA Grey
 class: FFF
 type: ASA
 abbreviation: ASA
 primary_color:
-  color_rgba: '#000000ff'
+  color_rgba: '#8f949bff'
 photos:
-- url: https://files.openprinttag.org/elegoo/elegoo-asa-black/130e85b202c5.png
+- url: https://cdn.shopify.com/s/files/1/0639/7660/3829/files/ASA_1KG_1.75mm_ca13e2d0-2da5-41f5-bcb1-68b8ef71a06a.jpg?v=1769592863
   type: unspecified
 properties:
   density: 1.09

--- a/data/materials/elegoo/elegoo-asa-red.yaml
+++ b/data/materials/elegoo/elegoo-asa-red.yaml
@@ -1,15 +1,15 @@
-uuid: 3738cd07-d915-57b5-8f66-fc131e9b01c8
-slug: elegoo-asa-black
+uuid: b23cd749-a639-5849-ab42-b1c6523610ee
+slug: elegoo-asa-red
 brand:
   slug: elegoo
-name: ASA Black
+name: ASA Red
 class: FFF
 type: ASA
 abbreviation: ASA
 primary_color:
-  color_rgba: '#000000ff'
+  color_rgba: '#d61212ff'
 photos:
-- url: https://files.openprinttag.org/elegoo/elegoo-asa-black/130e85b202c5.png
+- url: https://cdn.shopify.com/s/files/1/0639/7660/3829/files/ASA_1KG_1.75mm_785f0758-36bd-4aef-bc72-161304cdba09.jpg?v=1769592863
   type: unspecified
 properties:
   density: 1.09

--- a/data/materials/elegoo/elegoo-asa-white.yaml
+++ b/data/materials/elegoo/elegoo-asa-white.yaml
@@ -11,4 +11,14 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-asa-white/0ee4ff1bedd9.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.09
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 90
+  max_bed_temperature: 100
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60
+  drying_temperature: 80
+  drying_time: 480
+  min_nozzle_diameter: 200


### PR DESCRIPTION
Fills out the ELEGOO ASA line — adds print specifications and 1kg packages to the
existing colors and adds the colors ELEGOO sells that were missing.
  
  ### Materials
  - **Enriched (2):** ASA Black, ASA White — added properties (were empty).
  - **New (4):** ASA Blue, ASA Grey, ASA Red, ASA Green — color (Green left without a
    hex for now), photo, and properties.
    
  Properties from the official ELEGOO ASA spec sheet (same for all):
  - Nozzle 240–270 °C, bed 90–100 °C, chamber 45–60 °C (enclosure required)
  - Drying 80 °C / 8 h, density 1.09 g/cm³, recommended nozzle ≥0.2 mm
  - Spec-sheet values with no schema field (melt index, melting temp, Vicat, HDT,
    tensile/elongation/bending/impact, print speed, humidity) are omitted.
    
  ### Packages (6, new)
  - `elegoo-asa-{color}-1kg`, 1000 g, 1.75 mm, on `elegoo-cardboard-spool-1kg`
  - `brand_specific_id` = ELEGOO SKU (SPUS-EL-3DF-AS07xx); variant product URL on the package
  - GTIN-less for now (no barcodes on the listing) — backfillable later

  Product: https://us.elegoo.com/products/asa-filament-1-75mm-colored-1kg
  `make validate` passes; README/manifest untouched.