### PR TITLE
Add specs, high-speed tag, and 1kg packages for ELEGOO Rapid PETG line

### DIFF
--- a/data/material-packages/elegoo/elegoo-rapid-petg-beige-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-petg-beige-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-rapid-petg-beige-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PTG-112
+url: https://us.elegoo.com/products/rapid-petg-filament-1-75mm-colored-1kg?variant=44284016427189
+material:
+  slug: elegoo-rapid-petg-beige
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-petg-black-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-petg-black-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-rapid-petg-black-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PTG-101
+url: https://us.elegoo.com/products/rapid-petg-filament-1-75mm-colored-1kg?variant=43734204252341
+material:
+  slug: elegoo-rapid-petg-black
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-petg-blue-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-petg-blue-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-rapid-petg-blue-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PTG-104
+url: https://us.elegoo.com/products/rapid-petg-filament-1-75mm-colored-1kg?variant=43734204350645
+material:
+  slug: elegoo-rapid-petg-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-petg-brown-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-petg-brown-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-rapid-petg-brown-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PTG-110
+url: https://us.elegoo.com/products/rapid-petg-filament-1-75mm-colored-1kg?variant=44284016361653
+material:
+  slug: elegoo-rapid-petg-brown
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-petg-green-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-petg-green-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-rapid-petg-green-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PTG-105
+url: https://us.elegoo.com/products/rapid-petg-filament-1-75mm-colored-1kg?variant=43734204383413
+material:
+  slug: elegoo-rapid-petg-green
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-petg-grey-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-petg-grey-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-rapid-petg-grey-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PTG-107
+url: https://us.elegoo.com/products/rapid-petg-filament-1-75mm-colored-1kg?variant=43734204448949
+material:
+  slug: elegoo-rapid-petg-grey
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-petg-orange-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-petg-orange-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-rapid-petg-orange-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PTG-108
+url: https://us.elegoo.com/products/rapid-petg-filament-1-75mm-colored-1kg?variant=43734204481717
+material:
+  slug: elegoo-rapid-petg-orange
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-petg-red-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-petg-red-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-rapid-petg-red-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PTG-103
+url: https://us.elegoo.com/products/rapid-petg-filament-1-75mm-colored-1kg?variant=43734204317877
+material:
+  slug: elegoo-rapid-petg-red
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-petg-space-grey-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-petg-space-grey-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-rapid-petg-space-grey-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PTG-113
+url: https://us.elegoo.com/products/rapid-petg-filament-1-75mm-colored-1kg?variant=44284016459957
+material:
+  slug: elegoo-rapid-petg-space-grey
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-petg-transparent-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-petg-transparent-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-rapid-petg-transparent-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PTG-111
+url: https://us.elegoo.com/products/rapid-petg-filament-1-75mm-colored-1kg?variant=44614467485877
+material:
+  slug: elegoo-rapid-petg-transparent
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-petg-white-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-petg-white-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-rapid-petg-white-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PTG-102
+url: https://us.elegoo.com/products/rapid-petg-filament-1-75mm-colored-1kg?variant=43734204285109
+material:
+  slug: elegoo-rapid-petg-white
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/elegoo/elegoo-rapid-petg-yellow-1kg.yaml
+++ b/data/material-packages/elegoo/elegoo-rapid-petg-yellow-1kg.yaml
@@ -1,0 +1,10 @@
+slug: elegoo-rapid-petg-yellow-1kg
+class: FFF
+brand_specific_id: SPUS-EL-PTG-106
+url: https://us.elegoo.com/products/rapid-petg-filament-1-75mm-colored-1kg?variant=43734204416181
+material:
+  slug: elegoo-rapid-petg-yellow
+nominal_netto_full_weight: 1000
+container:
+  slug: elegoo-cardboard-spool-1kg
+filament_diameter: 1750

--- a/data/materials/elegoo/elegoo-rapid-petg-beige.yaml
+++ b/data/materials/elegoo/elegoo-rapid-petg-beige.yaml
@@ -8,7 +8,17 @@ type: PETG
 abbreviation: PETG
 primary_color:
   color_rgba: '#eadac2ff'
+tags:
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-petg-beige/1dce053c38cc.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.29
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 65
+  max_bed_temperature: 75
+  drying_temperature: 60
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-petg-black.yaml
+++ b/data/materials/elegoo/elegoo-rapid-petg-black.yaml
@@ -8,7 +8,17 @@ type: PETG
 abbreviation: PETG
 primary_color:
   color_rgba: '#000000ff'
+tags:
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-petg-black/f29fbb58429b.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.29
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 65
+  max_bed_temperature: 75
+  drying_temperature: 60
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-petg-blue.yaml
+++ b/data/materials/elegoo/elegoo-rapid-petg-blue.yaml
@@ -8,7 +8,17 @@ type: PETG
 abbreviation: PETG
 primary_color:
   color_rgba: '#2e56f1ff'
+tags:
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-petg-blue/d9b7c399bc0c.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.29
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 65
+  max_bed_temperature: 75
+  drying_temperature: 60
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-petg-brown.yaml
+++ b/data/materials/elegoo/elegoo-rapid-petg-brown.yaml
@@ -8,7 +8,17 @@ type: PETG
 abbreviation: PETG
 primary_color:
   color_rgba: '#9f563eff'
+tags:
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-petg-brown/988502b54078.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.29
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 65
+  max_bed_temperature: 75
+  drying_temperature: 60
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-petg-green.yaml
+++ b/data/materials/elegoo/elegoo-rapid-petg-green.yaml
@@ -8,7 +8,17 @@ type: PETG
 abbreviation: PETG
 primary_color:
   color_rgba: '#26a648ff'
+tags:
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-petg-green/48a7f2bc0e22.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.29
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 65
+  max_bed_temperature: 75
+  drying_temperature: 60
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-petg-grey.yaml
+++ b/data/materials/elegoo/elegoo-rapid-petg-grey.yaml
@@ -8,7 +8,17 @@ type: PETG
 abbreviation: PETG
 primary_color:
   color_rgba: '#c5c5bfff'
+tags:
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-petg-grey/3dfc6ba3505a.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.29
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 65
+  max_bed_temperature: 75
+  drying_temperature: 60
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-petg-orange.yaml
+++ b/data/materials/elegoo/elegoo-rapid-petg-orange.yaml
@@ -8,7 +8,17 @@ type: PETG
 abbreviation: PETG
 primary_color:
   color_rgba: '#ff8e24ff'
+tags:
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-petg-orange/2ae33283959c.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.29
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 65
+  max_bed_temperature: 75
+  drying_temperature: 60
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-petg-red.yaml
+++ b/data/materials/elegoo/elegoo-rapid-petg-red.yaml
@@ -8,7 +8,17 @@ type: PETG
 abbreviation: PETG
 primary_color:
   color_rgba: '#e72f1dff'
+tags:
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-petg-red/63cd6782ac83.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.29
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 65
+  max_bed_temperature: 75
+  drying_temperature: 60
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-petg-space-grey.yaml
+++ b/data/materials/elegoo/elegoo-rapid-petg-space-grey.yaml
@@ -8,7 +8,17 @@ type: PETG
 abbreviation: PETG
 primary_color:
   color_rgba: '#6a6c6eff'
+tags:
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-petg-space-grey/edf0c4f8fe79.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.29
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 65
+  max_bed_temperature: 75
+  drying_temperature: 60
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-petg-transparent.yaml
+++ b/data/materials/elegoo/elegoo-rapid-petg-transparent.yaml
@@ -10,7 +10,16 @@ primary_color:
   color_rgba: '#e4e7e5ff'
 tags:
 - transparent
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-petg-transparent/5db2ca2f5bf6.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.29
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 65
+  max_bed_temperature: 75
+  drying_temperature: 60
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-petg-white.yaml
+++ b/data/materials/elegoo/elegoo-rapid-petg-white.yaml
@@ -8,7 +8,17 @@ type: PETG
 abbreviation: PETG
 primary_color:
   color_rgba: '#ffffffff'
+tags:
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-petg-white/ed47251c1ca2.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.29
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 65
+  max_bed_temperature: 75
+  drying_temperature: 60
+  drying_time: 480
+  min_nozzle_diameter: 200

--- a/data/materials/elegoo/elegoo-rapid-petg-yellow.yaml
+++ b/data/materials/elegoo/elegoo-rapid-petg-yellow.yaml
@@ -8,7 +8,17 @@ type: PETG
 abbreviation: PETG
 primary_color:
   color_rgba: '#fbe200ff'
+tags:
+- high_speed
 photos:
 - url: https://files.openprinttag.org/elegoo/elegoo-rapid-petg-yellow/3c5959d3c72d.png
   type: unspecified
-properties: {}
+properties:
+  density: 1.29
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 65
+  max_bed_temperature: 75
+  drying_temperature: 60
+  drying_time: 480
+  min_nozzle_diameter: 200


### PR DESCRIPTION
  Fills out the ELEGOO Rapid PETG line — all 12 colors already existed (color + photo)
  but had no specs or packages. This adds print specifications, the high_speed tag,
  and a 1kg package per color.
 
  ### Materials (12, enriched)
  Black, White, Red, Blue, Green, Yellow, Grey, Orange, Brown, Transparent, Beige, Space Grey
  - Properties from the official ELEGOO Rapid PETG spec sheet:
    - Nozzle 240–270 °C, bed 65–75 °C, drying 60 °C / 8 h, density 1.29 g/cm³, nozzle ≥0.2 mm
    - Chamber omitted (enclosure "Not Required").
  - Tag `high_speed` added (Rapid line, <600 mm/s, "high-speed printing" key feature).
  - Spec-sheet values with no schema field (melt index, melting temp, Vicat, HDT,
    tensile/elongation/bending/impact, print speed, humidity) are omitted.
  - Colors and photos unchanged.
 
  ### Packages (12, new)
  - `elegoo-rapid-petg-{color}-1kg`, 1000 g, 1.75 mm, on `elegoo-cardboard-spool-1kg`
  - `brand_specific_id` = ELEGOO SKU (SPUS-EL-PTG-1xx); variant product URL on the package
  - GTIN-less for now (no barcodes on the listing) — backfillable later

  Product: https://us.elegoo.com/products/rapid-petg-filament-1-75mm-colored-1kg
  `make validate` passes; README/manifest untouched.