### PR TITLE
Add specs for Hatchbox PLA line and 1kg packages for current colors;

### DIFF
--- a/data/material-containers/hatchbox-spool-1kg.yaml
+++ b/data/material-containers/hatchbox-spool-1kg.yaml
@@ -4,4 +4,7 @@ name: Hatchbox Spool 1kg
 class: FFF
 brand:
   slug: hatchbox
+hole_diameter: 54.5
+outer_diameter: 198
+width: 68
 empty_weight: 245

--- a/data/material-packages/hatchbox/hatchbox-baby-blue-pla-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-baby-blue-pla-1kg.yaml
@@ -1,0 +1,9 @@
+slug: hatchbox-baby-blue-pla-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-bblu
+material:
+  slug: hatchbox-baby-blue-pla
+nominal_netto_full_weight: 1000
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/hatchbox/hatchbox-black-pla-filament-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-black-pla-filament-1kg.yaml
@@ -1,0 +1,9 @@
+slug: hatchbox-black-pla-filament-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-blk
+material:
+  slug: hatchbox-black-pla-filament
+nominal_netto_full_weight: 1000
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/hatchbox/hatchbox-blue-pla-filament-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-blue-pla-filament-1kg.yaml
@@ -1,0 +1,9 @@
+slug: hatchbox-blue-pla-filament-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-blu
+material:
+  slug: hatchbox-blue-pla-filament
+nominal_netto_full_weight: 1000
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/hatchbox/hatchbox-gray-pla-filament-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-gray-pla-filament-1kg.yaml
@@ -1,0 +1,9 @@
+slug: hatchbox-gray-pla-filament-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-gry
+material:
+  slug: hatchbox-gray-pla-filament
+nominal_netto_full_weight: 1000
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/hatchbox/hatchbox-light-orange-pla-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-light-orange-pla-1kg.yaml
@@ -1,0 +1,9 @@
+slug: hatchbox-light-orange-pla-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-lorg
+material:
+  slug: hatchbox-light-orange-pla
+nominal_netto_full_weight: 1000
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/hatchbox/hatchbox-light-purple-pla-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-light-purple-pla-1kg.yaml
@@ -1,0 +1,9 @@
+slug: hatchbox-light-purple-pla-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-lpur
+material:
+  slug: hatchbox-light-purple-pla
+nominal_netto_full_weight: 1000
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/hatchbox/hatchbox-midnight-purple-pla-filament-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-midnight-purple-pla-filament-1kg.yaml
@@ -1,0 +1,9 @@
+slug: hatchbox-midnight-purple-pla-filament-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-mpur
+material:
+  slug: hatchbox-midnight-purple-pla-filament
+nominal_netto_full_weight: 1000
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/hatchbox/hatchbox-natural-pla-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-natural-pla-1kg.yaml
@@ -1,0 +1,9 @@
+slug: hatchbox-natural-pla-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-nat
+material:
+  slug: hatchbox-natural-pla
+nominal_netto_full_weight: 1000
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/hatchbox/hatchbox-pink-pla-filament-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-pink-pla-filament-1kg.yaml
@@ -1,0 +1,9 @@
+slug: hatchbox-pink-pla-filament-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-pnk
+material:
+  slug: hatchbox-pink-pla-filament
+nominal_netto_full_weight: 1000
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/hatchbox/hatchbox-purple-pla-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-purple-pla-1kg.yaml
@@ -1,0 +1,9 @@
+slug: hatchbox-purple-pla-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-pur
+material:
+  slug: hatchbox-purple-pla
+nominal_netto_full_weight: 1000
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/hatchbox/hatchbox-silver-pla-filament-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-silver-pla-filament-1kg.yaml
@@ -1,0 +1,9 @@
+slug: hatchbox-silver-pla-filament-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-slv
+material:
+  slug: hatchbox-silver-pla-filament
+nominal_netto_full_weight: 1000
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/hatchbox/hatchbox-white-pla-filament-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-white-pla-filament-1kg.yaml
@@ -1,0 +1,9 @@
+slug: hatchbox-white-pla-filament-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-wht
+material:
+  slug: hatchbox-white-pla-filament
+nominal_netto_full_weight: 1000
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/hatchbox/hatchbox-yellow-pla-filament-1kg.yaml
+++ b/data/material-packages/hatchbox/hatchbox-yellow-pla-filament-1kg.yaml
@@ -1,0 +1,9 @@
+slug: hatchbox-yellow-pla-filament-1kg
+class: FFF
+url: https://www.hatchbox3d.com/products/3d-pla-1kg1-75-ylw
+material:
+  slug: hatchbox-yellow-pla-filament
+nominal_netto_full_weight: 1000
+container:
+  slug: hatchbox-spool-1kg
+filament_diameter: 1750

--- a/data/materials/hatchbox/hatchbox-baby-blue-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-baby-blue-pla.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-baby-blue-pla/12652fe42eb3.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-beige-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-beige-pla.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-beige-pla/ecabe21c9200.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-black-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-black-pla-filament.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-black-pla-filament/01dd3914e67d.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-blue-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-blue-pla-filament.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-blue-pla-filament/ce3a7446677e.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-bronze-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-bronze-pla.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-bronze-pla/9c29a4dbb220.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-brown-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-brown-pla.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-brown-pla/52566ff6601c.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-copper-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-copper-pla.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-copper-pla/55227e2cc329.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-forest-green-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-forest-green-pla-filament.yaml
@@ -13,3 +13,7 @@ photos:
   type: package
 properties:
   density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-gray-blue-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-gray-blue-pla.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-gray-blue-pla/5c230ed404c9.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-gray-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-gray-pla-filament.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-gray-pla-filament/05790720c9b1.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-green-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-green-pla-filament.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-green-pla-filament/9d370339876a.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-light-blue-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-light-blue-pla-filament.yaml
@@ -13,3 +13,7 @@ photos:
   type: package
 properties:
   density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-light-orange-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-light-orange-pla.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-light-orange-pla/5899b569200d.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-light-purple-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-light-purple-pla.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-light-purple-pla/f25b44f2ff09.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-midnight-purple-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-midnight-purple-pla-filament.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-midnight-purple-pla-filament/5a07e8ee8c28.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-mint-green-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-mint-green-pla.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-mint-green-pla/4acd308e0fb2.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-natural-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-natural-pla.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-natural-pla/38df4c0192d6.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-neon-green-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-neon-green-pla.yaml
@@ -14,4 +14,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-neon-green-pla/93ba3a36ef28.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-orange-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-orange-pla-filament.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-orange-pla-filament/ad64c07e191c.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-pastel-green-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-pastel-green-pla.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-pastel-green-pla/3c286e394cba.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-peacock-blue-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-peacock-blue-pla.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-peacock-blue-pla/d80fba0f3f5a.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-pink-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-pink-pla-filament.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-pink-pla-filament/56001c8e4e65.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-purple-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-purple-pla.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-purple-pla/d88b3e603a04.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-red-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-red-pla-filament.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-red-pla-filament/617bb3286502.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-silver-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-silver-pla-filament.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-silver-pla-filament/0d68d72208ac.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-stone-red-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-stone-red-pla.yaml
@@ -14,4 +14,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-stone-red-pla/8158e824bd76.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-white-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-white-pla-filament.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-white-pla-filament/0f13d0266896.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60

--- a/data/materials/hatchbox/hatchbox-yellow-pla-filament.yaml
+++ b/data/materials/hatchbox/hatchbox-yellow-pla-filament.yaml
@@ -13,4 +13,9 @@ tags:
 photos:
 - url: https://files.openprinttag.org/hatchbox/hatchbox-yellow-pla-filament/d5ef17edd41f.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.27
+  min_print_temperature: 180
+  max_print_temperature: 210
+  min_bed_temperature: 50
+  max_bed_temperature: 60


### PR DESCRIPTION
  Fills out the Hatchbox standard PLA line — adds print specifications to all 28 colors
  and 1kg packages for the colors currently sold, and enriches the spool container.
  
  ### Materials (28, enriched)
  - All standard-PLA colors now carry the full property block from Hatchbox's spec sheet/SDS:
    density 1.27 g/cm³, nozzle 180–210 °C, bed 50–60 °C.
  - Colors and photos were already present and are unchanged.
  - (Forest Green and Light Blue were previously density-only; upgraded to the full temp block.)
  
  ### Packages (13, new)
  - 1kg packages on `hatchbox-spool-1kg` for the colors currently listed: Black, White, Blue,
    Yellow, Baby Blue, Gray, Light Orange, Light Purple, Midnight Purple, Natural, Pink, Purple, Silver.
  - Per-color product URL on each package. GTIN-less for now (backfillable later). 
  - Colors that Hatchbox no longer sells in the basic PLA line were left specs-only (no package):
    Beige, Bronze, Brown, Copper, Gray Blue, Green, Mint Green, Neon Green, Orange, Pastel Green,
    Peacock Blue, Red, Stone Red. 
    
  ### Container
  - `hatchbox-spool-1kg` — added measured dimensions: hole 54.5 mm, outer 198 mm, width 68 mm
    (empty weight 245 g unchanged).
    
  `make validate` passes; README/manifest untouched.