### PR TITLE
Add specs and packages for SUNLU PLA+ line; add 12 new colors

### DIFF
--- a/data/material-containers/sunlu-reusable-spool-1kg.yaml
+++ b/data/material-containers/sunlu-reusable-spool-1kg.yaml
@@ -1,0 +1,10 @@
+uuid: 0420bfcd-826b-4d11-ac52-0124f2dec362
+slug: sunlu-reusable-spool-1kg
+name: SUNLU Reusable Spool 1kg
+class: FFF
+brand:
+  slug: sunlu
+hole_diameter: 62
+outer_diameter: 190
+width: 60
+empty_weight: 169

--- a/data/material-packages/sunlu/sunlu-pla-plus-beige-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-beige-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-beige-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-beige
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-black-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-black-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-black-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-black
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-bone-white-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-bone-white-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-bone-white-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-bone-white
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-ceramic-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-ceramic-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-ceramic-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-ceramic
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-coffee-brown-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-coffee-brown-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-coffee-brown-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-coffee-brown
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-cyan-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-cyan-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-cyan-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-cyan
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-green-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-green-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-green-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-green
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-grey-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-grey-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-grey-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-grey
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-klein-blue-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-klein-blue-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-klein-blue-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-klein-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-lavender-purple-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-lavender-purple-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-lavender-purple-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-lavender-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-magenta-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-magenta-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-magenta-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-magenta
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-midnight-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-midnight-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-midnight-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-midnight
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-oak-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-oak-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-oak-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-oak
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-olive-green-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-olive-green-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-olive-green-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-olive-green
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-red-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-red-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-red-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-red
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-roasted-chestnut-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-roasted-chestnut-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-roasted-chestnut-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-roasted-chestnut
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-sunny-orange-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-sunny-orange-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-sunny-orange-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-sunny-orange
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-vivid-yellow-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-vivid-yellow-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-vivid-yellow-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-vivid-yellow
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-white-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-white-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-white-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-white
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/sunlu/sunlu-pla-plus-yellow-1kg.yaml
+++ b/data/material-packages/sunlu/sunlu-pla-plus-yellow-1kg.yaml
@@ -1,0 +1,9 @@
+slug: sunlu-pla-plus-yellow-1kg
+class: FFF
+url: https://www.sunlu.com/products/pla-plus-filament
+material:
+  slug: sunlu-pla-plus-yellow
+nominal_netto_full_weight: 1000
+container:
+  slug: sunlu-reusable-spool-1kg
+filament_diameter: 1750

--- a/data/materials/sunlu/sunlu-pla-plus-beige.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-beige.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-beige/6561a9426fbe.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-black.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-black.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-black/290063f395f1.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-blue.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-blue.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-blue/b01bce1bc1ca.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-bluegrey.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-bluegrey.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-bluegrey/7c1df7f52fa1.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-bone-white.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-bone-white.yaml
@@ -1,17 +1,15 @@
-uuid: 73f8234d-6c94-56bd-ae8c-ce522350b491
-slug: sunlu-pla-plus-pink
+uuid: 2e31da68-3e21-5bf4-8260-0768001f417f
+slug: sunlu-pla-plus-bone-white
 brand:
   slug: sunlu
-name: PLA Plus Pink
+name: PLA Plus Bone White
 class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#f297daff'
-tags:
-- industrially_compostable
+  color_rgba: '#e3e0d3ff'
 photos:
-- url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-pink/961c49c36e23.jpg
+- url: https://www.sunlu.com/public/upload/image/20260611/cf16d19f-6b51-49c0-82dc-05318d0d904e.png
   type: unspecified
 properties:
   density: 1.21

--- a/data/materials/sunlu/sunlu-pla-plus-ceramic.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-ceramic.yaml
@@ -1,17 +1,15 @@
-uuid: 73f8234d-6c94-56bd-ae8c-ce522350b491
-slug: sunlu-pla-plus-pink
+uuid: 6e6d8b12-8311-59ff-a854-25d75be9f7aa
+slug: sunlu-pla-plus-ceramic
 brand:
   slug: sunlu
-name: PLA Plus Pink
+name: PLA Plus Ceramic
 class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#f297daff'
-tags:
-- industrially_compostable
+  color_rgba: '#d9d9d9ff'
 photos:
-- url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-pink/961c49c36e23.jpg
+- url: https://www.sunlu.com/public/upload/image/20260611/69a4671d-5e96-472a-aa1d-54794d0cc91a.png
   type: unspecified
 properties:
   density: 1.21

--- a/data/materials/sunlu/sunlu-pla-plus-chocolate.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-chocolate.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-chocolate/02d71fe282f9.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-coffee-brown.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-coffee-brown.yaml
@@ -1,17 +1,15 @@
-uuid: 73f8234d-6c94-56bd-ae8c-ce522350b491
-slug: sunlu-pla-plus-pink
+uuid: 5daf85a1-f47b-541a-86ad-d00305f88757
+slug: sunlu-pla-plus-coffee-brown
 brand:
   slug: sunlu
-name: PLA Plus Pink
+name: PLA Plus Coffee Brown
 class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#f297daff'
-tags:
-- industrially_compostable
+  color_rgba: '#362111ff'
 photos:
-- url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-pink/961c49c36e23.jpg
+- url: https://www.sunlu.com/public/upload/image/20260611/6fb07c2b-4de9-4814-b120-d88b377cfaf5.png
   type: unspecified
 properties:
   density: 1.21

--- a/data/materials/sunlu/sunlu-pla-plus-coffee.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-coffee.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-coffee/3c0d9329b875.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-cyan.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-cyan.yaml
@@ -1,17 +1,13 @@
-uuid: 73f8234d-6c94-56bd-ae8c-ce522350b491
-slug: sunlu-pla-plus-pink
+uuid: e36cfc5f-124c-57ce-9c97-fc150345ac9f
+slug: sunlu-pla-plus-cyan
 brand:
   slug: sunlu
-name: PLA Plus Pink
+name: PLA Plus Cyan
 class: FFF
 type: PLA
 abbreviation: PLA
-primary_color:
-  color_rgba: '#f297daff'
-tags:
-- industrially_compostable
 photos:
-- url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-pink/961c49c36e23.jpg
+- url: https://www.sunlu.com/public/upload/image/20260611/f491a313-f676-47b3-82e9-19f954a45e0d.png
   type: unspecified
 properties:
   density: 1.21

--- a/data/materials/sunlu/sunlu-pla-plus-grassgreen.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-grassgreen.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-grassgreen/280a613c73da.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-green.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-green.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-green/37abeae53154.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-grey.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-grey.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-grey/6b0390a4e2b1.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-klein-blue.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-klein-blue.yaml
@@ -1,17 +1,15 @@
-uuid: 73f8234d-6c94-56bd-ae8c-ce522350b491
-slug: sunlu-pla-plus-pink
+uuid: d3494b46-f488-5692-8ea2-1339e038d3da
+slug: sunlu-pla-plus-klein-blue
 brand:
   slug: sunlu
-name: PLA Plus Pink
+name: PLA Plus Klein Blue
 class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#f297daff'
-tags:
-- industrially_compostable
+  color_rgba: '#1729abff'
 photos:
-- url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-pink/961c49c36e23.jpg
+- url: https://www.sunlu.com/public/upload/image/20260611/a51ec23c-cc2e-42a0-9eec-aefd1e2b2189.png
   type: unspecified
 properties:
   density: 1.21

--- a/data/materials/sunlu/sunlu-pla-plus-lavender-purple.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-lavender-purple.yaml
@@ -1,17 +1,15 @@
-uuid: 73f8234d-6c94-56bd-ae8c-ce522350b491
-slug: sunlu-pla-plus-pink
+uuid: c93a82bf-9f32-59c2-aa0a-3b34dc682b7b
+slug: sunlu-pla-plus-lavender-purple
 brand:
   slug: sunlu
-name: PLA Plus Pink
+name: PLA Plus Lavender Purple
 class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#f297daff'
-tags:
-- industrially_compostable
+  color_rgba: '#a54dcfff'
 photos:
-- url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-pink/961c49c36e23.jpg
+- url: https://www.sunlu.com/public/upload/image/20260611/f478fa7a-d5c3-416e-bc74-bbe9ace75203.png
   type: unspecified
 properties:
   density: 1.21

--- a/data/materials/sunlu/sunlu-pla-plus-light-gold.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-light-gold.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-light-gold/3fbe79a46346.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-magenta.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-magenta.yaml
@@ -1,17 +1,15 @@
-uuid: 73f8234d-6c94-56bd-ae8c-ce522350b491
-slug: sunlu-pla-plus-pink
+uuid: 22b6a92e-61c5-5e2f-9d45-d18351dbc36e
+slug: sunlu-pla-plus-magenta
 brand:
   slug: sunlu
-name: PLA Plus Pink
+name: PLA Plus Magenta
 class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#f297daff'
-tags:
-- industrially_compostable
+  color_rgba: '#f95e88ff'
 photos:
-- url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-pink/961c49c36e23.jpg
+- url: https://www.sunlu.com/public/upload/image/20260611/00b606fc-03de-4cce-a7ff-f678ede3502b.png
   type: unspecified
 properties:
   density: 1.21

--- a/data/materials/sunlu/sunlu-pla-plus-midnight.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-midnight.yaml
@@ -1,17 +1,15 @@
-uuid: 73f8234d-6c94-56bd-ae8c-ce522350b491
-slug: sunlu-pla-plus-pink
+uuid: 03d0d91c-6e3d-5ef2-b480-7184e1fdcaf4
+slug: sunlu-pla-plus-midnight
 brand:
   slug: sunlu
-name: PLA Plus Pink
+name: PLA Plus Midnight
 class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#f297daff'
-tags:
-- industrially_compostable
+  color_rgba: '#28334aff'
 photos:
-- url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-pink/961c49c36e23.jpg
+- url: https://www.sunlu.com/public/upload/image/20260611/c056a804-1fbe-482d-826e-31402b926237.png
   type: unspecified
 properties:
   density: 1.21

--- a/data/materials/sunlu/sunlu-pla-plus-mint-green.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-mint-green.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-mint-green/a59a9e6d13c9.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-oak.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-oak.yaml
@@ -1,17 +1,15 @@
-uuid: 73f8234d-6c94-56bd-ae8c-ce522350b491
-slug: sunlu-pla-plus-pink
+uuid: 72324823-810d-5198-be94-589e790ad9a2
+slug: sunlu-pla-plus-oak
 brand:
   slug: sunlu
-name: PLA Plus Pink
+name: PLA Plus Oak
 class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#f297daff'
-tags:
-- industrially_compostable
+  color_rgba: '#c2b29aff'
 photos:
-- url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-pink/961c49c36e23.jpg
+- url: https://www.sunlu.com/public/upload/image/20260611/49e621e3-2df4-47f2-bf1f-1e4590e27f3d.png
   type: unspecified
 properties:
   density: 1.21

--- a/data/materials/sunlu/sunlu-pla-plus-olive-green.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-olive-green.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-olive-green/5a16cd7ae263.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-orange.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-orange.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-orange/a2d493001913.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-pure-yellow.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-pure-yellow.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-pure-yellow/c408ebeb776e.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-purple.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-purple.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-purple/45f1e9610e5e.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-red.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-red.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-red/9ef44dcd7cd3.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-roasted-chestnut.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-roasted-chestnut.yaml
@@ -1,17 +1,13 @@
-uuid: 73f8234d-6c94-56bd-ae8c-ce522350b491
-slug: sunlu-pla-plus-pink
+uuid: 8f56e550-a7ed-517f-a1d5-bbc57549e9e1
+slug: sunlu-pla-plus-roasted-chestnut
 brand:
   slug: sunlu
-name: PLA Plus Pink
+name: PLA Plus Roasted Chestnut
 class: FFF
 type: PLA
 abbreviation: PLA
-primary_color:
-  color_rgba: '#f297daff'
-tags:
-- industrially_compostable
 photos:
-- url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-pink/961c49c36e23.jpg
+- url: https://www.sunlu.com/public/upload/image/20260611/9adc25f2-f67e-494d-88fe-d7b259c68dc3.png
   type: unspecified
 properties:
   density: 1.21

--- a/data/materials/sunlu/sunlu-pla-plus-silver.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-silver.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-silver/efce65a3680c.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-sunny-orange.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-sunny-orange.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-sunny-orange/8dcb19bafd94.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-vivid-yellow.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-vivid-yellow.yaml
@@ -1,17 +1,15 @@
-uuid: 73f8234d-6c94-56bd-ae8c-ce522350b491
-slug: sunlu-pla-plus-pink
+uuid: d66ae5c7-156b-51ad-a1c4-195182282b93
+slug: sunlu-pla-plus-vivid-yellow
 brand:
   slug: sunlu
-name: PLA Plus Pink
+name: PLA Plus Vivid Yellow
 class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#f297daff'
-tags:
-- industrially_compostable
+  color_rgba: '#ffff00ff'
 photos:
-- url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-pink/961c49c36e23.jpg
+- url: https://www.sunlu.com/public/upload/image/20260611/4ab60ddf-1a82-48b4-91be-825228352456.png
   type: unspecified
 properties:
   density: 1.21

--- a/data/materials/sunlu/sunlu-pla-plus-white.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-white.yaml
@@ -13,4 +13,11 @@ tags:
 photos:
 - url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-white/69f1968bc2a1.jpg
   type: unspecified
-properties: {}
+properties:
+  density: 1.21
+  hardness_shore_d: 81
+  min_print_temperature: 205
+  max_print_temperature: 245
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50

--- a/data/materials/sunlu/sunlu-pla-plus-yellow.yaml
+++ b/data/materials/sunlu/sunlu-pla-plus-yellow.yaml
@@ -1,17 +1,15 @@
-uuid: 73f8234d-6c94-56bd-ae8c-ce522350b491
-slug: sunlu-pla-plus-pink
+uuid: 2d12eb07-1af8-58ae-9ebc-82764f319cf2
+slug: sunlu-pla-plus-yellow
 brand:
   slug: sunlu
-name: PLA Plus Pink
+name: PLA Plus Yellow
 class: FFF
 type: PLA
 abbreviation: PLA
 primary_color:
-  color_rgba: '#f297daff'
-tags:
-- industrially_compostable
+  color_rgba: '#fff13fff'
 photos:
-- url: https://files.openprinttag.org/sunlu/sunlu-pla-plus-pink/961c49c36e23.jpg
+- url: https://www.sunlu.com/public/upload/image/20260611/df492c3c-a9d0-4349-96f1-7a9ef909454d.png
   type: unspecified
 properties:
   density: 1.21


### PR DESCRIPTION
  Fills out SUNLU's PLA+ line — adds print specs to existing colors, adds the new colors
  SUNLU now sells, and adds 1kg packages on the reusable spool.

  ### Materials
  - **Enriched (8 existing):** Grey, White, Black, Red, Green, Beige, Olive Green, Sunny Orange.
  - **New (12):** Yellow, Vivid Yellow, Ceramic, Bone White, Oak, Coffee Brown, Magenta, Midnight,
    Klein Blue, Lavender Purple (with hex) + Cyan, Roasted Chestnut (colorless for now) — each with
    its swatch photo.
  - **Discontinued (12):** existing PLA+ colors no longer in the live lineup left specs-only, no
    package (Blue, Bluegrey, Chocolate, Coffee, GrassGreen, Light Gold, Mint Green, Orange, Pink,
    Purple, Silver, Pure Yellow).
  - Properties from the SUNLU PLA+ technical data sheet: density 1.21 g/cm³, Shore D 81,
    nozzle 205–245 °C (full speed-banded envelope), bed 50–60 °C, drying 50 °C.
  - Spec-sheet values with no schema field (tensile, flexural, Izod, elongation, HDT, Tg, melt
    rate, shrinkage, print speed) are omitted. No existing colors were changed.
  - Out of scope (separate lines/batches): PLA+ Transparent variants, PLA+ Wood, "Upgrade PLA+"
    (the PLA+ 2.0 line), Silk PLA+ Rainbow.
    
  ### Container
  - `sunlu-reusable-spool-1kg` — plastic reusable spool, hole 62 / outer 190 / width 60 mm, empty 169 g.
    (Same container introduced in the SUNLU PLA PR; identical file.)

  ### Packages (20, new)
  - 1kg packages on `sunlu-reusable-spool-1kg` for the current colors; product-page URL
    (SUNLU lists one product with a color picker, no per-color URL/SKU); GTIN-less.

  Source: https://www.sunlu.com/products/pla-plus-filament
  `make validate` passes; README/manifest untouched.

  Note for you: this PR and the SUNLU PLA PR (#190) both add the identical sunlu-reusable-spool-1kg — whichever merges first, the other's identical add resolves cleanly on rebase.