### PR TITLE
Add CC3D PBT Pro Materials

### DIFF
--- a/data/materials/cc3d/cc3d-pbt-pro-black.yaml
+++ b/data/materials/cc3d/cc3d-pbt-pro-black.yaml
@@ -1,0 +1,18 @@
+uuid: 32a4c8a8-68ab-57d2-a284-e99623d516ab
+slug: cc3d-pbt-pro-black
+brand:
+  slug: cc3d
+name: PBT Pro Black
+class: FFF
+type: PBT
+abbreviation: PBT
+primary_color:
+  color_rgba: '#000000'
+tags:
+- abrasive
+- contains_glass
+- contains_glass_fiber
+properties:
+  min_print_temperature: 220
+  max_print_temperature: 250
+  min_bed_temperature: 60

--- a/data/materials/cc3d/cc3d-pbt-pro-blue.yaml
+++ b/data/materials/cc3d/cc3d-pbt-pro-blue.yaml
@@ -1,0 +1,18 @@
+uuid: a8d79503-fb8d-5f99-8c54-3d388eab6940
+slug: cc3d-pbt-pro-blue
+brand:
+  slug: cc3d
+name: PBT Pro Blue
+class: FFF
+type: PBT
+abbreviation: PBT
+primary_color:
+  color_rgba: '#066cd1'
+tags:
+- abrasive
+- contains_glass
+- contains_glass_fiber
+properties:
+  min_print_temperature: 220
+  max_print_temperature: 250
+  min_bed_temperature: 60

--- a/data/materials/cc3d/cc3d-pbt-pro-white.yaml
+++ b/data/materials/cc3d/cc3d-pbt-pro-white.yaml
@@ -1,0 +1,18 @@
+uuid: 0f5bd9f0-a0bc-5462-9534-421981e077fe
+slug: cc3d-pbt-pro-white
+brand:
+  slug: cc3d
+name: PBT Pro White
+class: FFF
+type: PBT
+abbreviation: PBT
+primary_color:
+  color_rgba: '#ffffff'
+tags:
+- abrasive
+- contains_glass
+- contains_glass_fiber
+properties:
+  min_print_temperature: 220
+  max_print_temperature: 250
+  min_bed_temperature: 60

--- a/data/materials/cc3d/cc3d-test-material.yaml
+++ b/data/materials/cc3d/cc3d-test-material.yaml
@@ -1,0 +1,1 @@
+HelloWorld!

--- a/data/materials/cc3d/cc3d-test-material.yaml
+++ b/data/materials/cc3d/cc3d-test-material.yaml
@@ -1,1 +1,2 @@
 HelloWorld!
+HEllO!

--- a/data/materials/cc3d/cc3d-test-material.yaml
+++ b/data/materials/cc3d/cc3d-test-material.yaml
@@ -1,2 +1,3 @@
 HelloWorld!
 HEllO!
+YO!


### PR DESCRIPTION
Added 3 Colors of CC3Ds PBT Pro GF

Heads Up: I deleted my old PR (#188)which only contained the black version of the material, now I added all colors and generated the correct UUIDs for them.