### PR TITLE
Edit 10 PA6,PA12 filaments (BambuLab)

### DIFF
--- a/data/material-packages/bambulab/bambulab-pa6-cf-black-1kg.yaml
+++ b/data/material-packages/bambulab/bambulab-pa6-cf-black-1kg.yaml
@@ -1,0 +1,7 @@
+slug: bambulab-pa6-cf-black-1kg
+class: FFF
+material:
+  slug: bambulab-pa6-cf-black
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+url: https://us.store.bambulab.com/products/pa6-cf?id=41270316630152

--- a/data/material-packages/bambulab/bambulab-pa6-cf-black-500g.yaml
+++ b/data/material-packages/bambulab/bambulab-pa6-cf-black-500g.yaml
@@ -1,0 +1,7 @@
+slug: bambulab-pa6-cf-black-500g
+class: FFF
+material:
+  slug: bambulab-pa6-cf-black
+nominal_netto_full_weight: 500
+filament_diameter: 1750
+url: https://us.store.bambulab.com/products/pa6-cf?id=41270316630152

--- a/data/material-packages/bambulab/bambulab-pa6-gf-black-1kg.yaml
+++ b/data/material-packages/bambulab/bambulab-pa6-gf-black-1kg.yaml
@@ -1,0 +1,7 @@
+slug: bambulab-pa6-gf-black-1kg
+class: FFF
+material:
+  slug: bambulab-pa6-gf-black
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+url: https://us.store.bambulab.com/products/pa6-gf?id=41924135944328

--- a/data/material-packages/bambulab/bambulab-pa6-gf-blue-1kg.yaml
+++ b/data/material-packages/bambulab/bambulab-pa6-gf-blue-1kg.yaml
@@ -1,0 +1,7 @@
+slug: bambulab-pa6-gf-blue-1kg
+class: FFF
+material:
+  slug: bambulab-pa6-gf-blue
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+url: https://us.store.bambulab.com/products/pa6-gf?id=41924135714952

--- a/data/material-packages/bambulab/bambulab-pa6-gf-brown-1kg.yaml
+++ b/data/material-packages/bambulab/bambulab-pa6-gf-brown-1kg.yaml
@@ -1,0 +1,7 @@
+slug: bambulab-pa6-gf-brown-1kg
+class: FFF
+material:
+  slug: bambulab-pa6-gf-brown
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+url: https://us.store.bambulab.com/products/pa6-gf?id=41924135846024

--- a/data/material-packages/bambulab/bambulab-pa6-gf-gray-1kg.yaml
+++ b/data/material-packages/bambulab/bambulab-pa6-gf-gray-1kg.yaml
@@ -1,0 +1,7 @@
+slug: bambulab-pa6-gf-gray-1kg
+class: FFF
+material:
+  slug: bambulab-pa6-gf-gray
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+url: https://us.store.bambulab.com/products/pa6-gf?id=41924135911560

--- a/data/material-packages/bambulab/bambulab-pa6-gf-lime-1kg.yaml
+++ b/data/material-packages/bambulab/bambulab-pa6-gf-lime-1kg.yaml
@@ -1,0 +1,7 @@
+slug: bambulab-pa6-gf-lime-1kg
+class: FFF
+material:
+  slug: bambulab-pa6-gf-lime
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+url: https://us.store.bambulab.com/products/pa6-gf?id=41924135813256

--- a/data/material-packages/bambulab/bambulab-pa6-gf-orange-1kg.yaml
+++ b/data/material-packages/bambulab/bambulab-pa6-gf-orange-1kg.yaml
@@ -1,0 +1,7 @@
+slug: bambulab-pa6-gf-orange-1kg
+class: FFF
+material:
+  slug: bambulab-pa6-gf-orange
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+url: https://us.store.bambulab.com/products/pa6-gf?id=41924135747720

--- a/data/material-packages/bambulab/bambulab-pa6-gf-white-1kg.yaml
+++ b/data/material-packages/bambulab/bambulab-pa6-gf-white-1kg.yaml
@@ -1,0 +1,7 @@
+slug: bambulab-pa6-gf-white-1kg
+class: FFF
+material:
+  slug: bambulab-pa6-gf-white
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+url: https://us.store.bambulab.com/products/pa6-gf?id=41924135878792

--- a/data/material-packages/bambulab/bambulab-pa6-gf-yellow-1kg.yaml
+++ b/data/material-packages/bambulab/bambulab-pa6-gf-yellow-1kg.yaml
@@ -1,0 +1,7 @@
+slug: bambulab-pa6-gf-yellow-1kg
+class: FFF
+material:
+  slug: bambulab-pa6-gf-yellow
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+url: https://us.store.bambulab.com/products/pa6-gf?id=41924135780488

--- a/data/material-packages/bambulab/bambulab-paht-cf-black-1kg.yaml
+++ b/data/material-packages/bambulab/bambulab-paht-cf-black-1kg.yaml
@@ -1,0 +1,7 @@
+slug: bambulab-paht-cf-black-1kg
+class: FFF
+material:
+  slug: bambulab-paht-cf-black
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+url: https://us.store.bambulab.com/products/paht-cf?id=41009450483848

--- a/data/material-packages/bambulab/bambulab-paht-cf-black-500g.yaml
+++ b/data/material-packages/bambulab/bambulab-paht-cf-black-500g.yaml
@@ -1,0 +1,7 @@
+slug: bambulab-paht-cf-black-500g
+class: FFF
+material:
+  slug: bambulab-paht-cf-black
+nominal_netto_full_weight: 500
+filament_diameter: 1750
+url: https://us.store.bambulab.com/products/paht-cf?id=41009450483848

--- a/data/materials/bambulab/bambulab-pa6-cf-black.yaml
+++ b/data/materials/bambulab/bambulab-pa6-cf-black.yaml
@@ -9,9 +9,18 @@ abbreviation: PA6
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/bambulab/bambulab-pa6-cf-black/cac10a548109.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/bambulab/bambulab-pa6-cf-black/cac10a548109.png
+    type: unspecified
+properties:
+  density: 1.09
+  min_print_temperature: 260
+  max_print_temperature: 290
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60

--- a/data/materials/bambulab/bambulab-pa6-gf-black.yaml
+++ b/data/materials/bambulab/bambulab-pa6-gf-black.yaml
@@ -9,9 +9,18 @@ abbreviation: PA6
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_glass_fiber
-- abrasive
+  - contains_glass_fiber
+  - abrasive
+  - contains_glass
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-black/03ba8d36e117.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-black/03ba8d36e117.png
+    type: unspecified
+properties:
+  density: 1.14
+  min_print_temperature: 260
+  max_print_temperature: 290
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60

--- a/data/materials/bambulab/bambulab-pa6-gf-blue.yaml
+++ b/data/materials/bambulab/bambulab-pa6-gf-blue.yaml
@@ -7,11 +7,20 @@ class: FFF
 type: PA6
 abbreviation: PA6
 primary_color:
-  color_rgba: '#6299dfff'
+  color_rgba: '#75aed8ff'
 tags:
-- contains_glass_fiber
-- abrasive
+  - contains_glass_fiber
+  - abrasive
+  - contains_glass
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-blue/4e256f157f27.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-blue/4e256f157f27.png
+    type: unspecified
+properties:
+  density: 1.14
+  min_print_temperature: 260
+  max_print_temperature: 290
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60

--- a/data/materials/bambulab/bambulab-pa6-gf-brown.yaml
+++ b/data/materials/bambulab/bambulab-pa6-gf-brown.yaml
@@ -9,9 +9,18 @@ abbreviation: PA6
 primary_color:
   color_rgba: '#b38f6eff'
 tags:
-- contains_glass_fiber
-- abrasive
+  - contains_glass_fiber
+  - abrasive
+  - contains_glass
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-brown/c7759c4653f7.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-brown/c7759c4653f7.png
+    type: unspecified
+properties:
+  density: 1.14
+  min_print_temperature: 260
+  max_print_temperature: 290
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60

--- a/data/materials/bambulab/bambulab-pa6-gf-gray.yaml
+++ b/data/materials/bambulab/bambulab-pa6-gf-gray.yaml
@@ -7,11 +7,20 @@ class: FFF
 type: PA6
 abbreviation: PA6
 primary_color:
-  color_rgba: '#55555eff'
+  color_rgba: '#353533ff'
 tags:
-- contains_glass_fiber
-- abrasive
+  - contains_glass_fiber
+  - abrasive
+  - contains_glass
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-gray/b7aaf25733be.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-gray/b7aaf25733be.png
+    type: unspecified
+properties:
+  density: 1.14
+  min_print_temperature: 260
+  max_print_temperature: 290
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60

--- a/data/materials/bambulab/bambulab-pa6-gf-lime.yaml
+++ b/data/materials/bambulab/bambulab-pa6-gf-lime.yaml
@@ -7,11 +7,20 @@ class: FFF
 type: PA6
 abbreviation: PA6
 primary_color:
-  color_rgba: '#bbdb4bff'
+  color_rgba: '#c5ed48ff'
 tags:
-- contains_glass_fiber
-- abrasive
+  - contains_glass_fiber
+  - abrasive
+  - contains_glass
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-lime/96eaab4131ef.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-lime/96eaab4131ef.png
+    type: unspecified
+properties:
+  density: 1.14
+  min_print_temperature: 360
+  max_print_temperature: 290
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60

--- a/data/materials/bambulab/bambulab-pa6-gf-orange.yaml
+++ b/data/materials/bambulab/bambulab-pa6-gf-orange.yaml
@@ -7,11 +7,20 @@ class: FFF
 type: PA6
 abbreviation: PA6
 primary_color:
-  color_rgba: '#ff5f2eff'
+  color_rgba: '#ff4800ff'
 tags:
-- contains_glass_fiber
-- abrasive
+  - contains_glass_fiber
+  - abrasive
+  - contains_glass
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-orange/445ecee96d43.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-orange/445ecee96d43.png
+    type: unspecified
+properties:
+  density: 1.14
+  min_print_temperature: 260
+  max_print_temperature: 290
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60

--- a/data/materials/bambulab/bambulab-pa6-gf-white.yaml
+++ b/data/materials/bambulab/bambulab-pa6-gf-white.yaml
@@ -9,9 +9,18 @@ abbreviation: PA6
 primary_color:
   color_rgba: '#ffffffff'
 tags:
-- contains_glass_fiber
-- abrasive
+  - contains_glass_fiber
+  - abrasive
+  - contains_glass
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-white/47067fbbcec4.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-white/47067fbbcec4.png
+    type: unspecified
+properties:
+  density: 1.14
+  min_print_temperature: 260
+  max_print_temperature: 290
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60

--- a/data/materials/bambulab/bambulab-pa6-gf-yellow.yaml
+++ b/data/materials/bambulab/bambulab-pa6-gf-yellow.yaml
@@ -7,11 +7,20 @@ class: FFF
 type: PA6
 abbreviation: PA6
 primary_color:
-  color_rgba: '#fbe200ff'
+  color_rgba: '#ffce00ff'
 tags:
-- contains_glass_fiber
-- abrasive
+  - contains_glass_fiber
+  - abrasive
+  - contains_glass
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-yellow/bb3e095cf01f.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/bambulab/bambulab-pa6-gf-yellow/bb3e095cf01f.png
+    type: unspecified
+properties:
+  density: 1.14
+  min_print_temperature: 260
+  max_print_temperature: 290
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60

--- a/data/materials/bambulab/bambulab-paht-cf-black.yaml
+++ b/data/materials/bambulab/bambulab-paht-cf-black.yaml
@@ -9,10 +9,19 @@ abbreviation: PA12
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- high_temperature
-- abrasive
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
+  - high_temperature
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/bambulab/bambulab-paht-cf-black/c6de55ef1656.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/bambulab/bambulab-paht-cf-black/c6de55ef1656.png
+    type: unspecified
+properties:
+  density: 1.06
+  min_print_temperature: 260
+  max_print_temperature: 290
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  min_chamber_temperature: 45
+  max_chamber_temperature: 60


### PR DESCRIPTION
Added missing properties and packages.
Fixed color hex codes according to Bambu Lab's website. 

- PA6-GF
- PA6-CF
- PAHT-CF (PA12)
