### PR TITLE
Added drying temperature and time for various Addnorth petg filaments

### DIFF
--- a/data/materials/addnorth/addnorth-esd-petg-black.yaml
+++ b/data/materials/addnorth/addnorth-esd-petg-black.yaml
@@ -18,3 +18,5 @@ properties:
   max_print_temperature: 270
   min_bed_temperature: 80
   max_bed_temperature: 85
+  drying_temperature: 65
+  drying_time: 360

--- a/data/materials/addnorth/addnorth-petg-flame-retardant-v0-black.yaml
+++ b/data/materials/addnorth/addnorth-petg-flame-retardant-v0-black.yaml
@@ -19,4 +19,6 @@ properties:
   max_print_temperature: 260
   min_bed_temperature: 0
   max_bed_temperature: 80
+  drying_temperature: 65
+  drying_time: 360
 url: https://addnorth.com/product/PETG%20Flame%20Retardant%20V0/PETG%20Flame%20Retardant%20V0%20-%201.75mm%20-%20750g%20-%20Black

--- a/data/materials/addnorth/addnorth-petg-flame-retardant-v0-natural.yaml
+++ b/data/materials/addnorth/addnorth-petg-flame-retardant-v0-natural.yaml
@@ -19,4 +19,6 @@ properties:
   max_print_temperature: 260
   min_bed_temperature: 0
   max_bed_temperature: 80
+  drying_temperature: 65
+  drying_time: 360
 url: https://addnorth.com/product/PETG%20Flame%20Retardant%20V0/PETG%20Flame%20Retardant%20V0%20-%201.75mm%20-%20750g%20-%20Natural

--- a/data/materials/addnorth/addnorth-petg-flame-retardant-v0-white.yaml
+++ b/data/materials/addnorth/addnorth-petg-flame-retardant-v0-white.yaml
@@ -19,4 +19,6 @@ properties:
   max_print_temperature: 260
   min_bed_temperature: 0
   max_bed_temperature: 80
+  drying_temperature: 65
+  drying_time: 360
 url: https://addnorth.com/product/PETG%20Flame%20Retardant%20V0/PETG%20Flame%20Retardant%20V0%20-%201.75mm%20-%20750g%20-%20White

--- a/data/materials/addnorth/addnorth-petg-pro-matte-black.yaml
+++ b/data/materials/addnorth/addnorth-petg-pro-matte-black.yaml
@@ -19,4 +19,6 @@ properties:
   max_print_temperature: 260
   min_bed_temperature: 0
   max_bed_temperature: 80
+  drying_temperature: 65
+  drying_time: 360
 url: https://addnorth.com/product/PETG%20PRO%20Matte/PETG%20PRO%20Matte%20-%202.85mm%20-%20750g%20-%20Black

--- a/data/materials/addnorth/addnorth-petg-pro-matte-white.yaml
+++ b/data/materials/addnorth/addnorth-petg-pro-matte-white.yaml
@@ -19,4 +19,6 @@ properties:
   max_print_temperature: 260
   min_bed_temperature: 0
   max_bed_temperature: 80
+  drying_temperature: 65
+  drying_time: 360
 url: https://addnorth.com/product/PETG%20PRO%20Matte/PETG%20PRO%20Matte%20-%201.75mm%20-%20750g%20-%20White

--- a/data/materials/addnorth/addnorth-petg-red.yaml
+++ b/data/materials/addnorth/addnorth-petg-red.yaml
@@ -17,4 +17,6 @@ properties:
   max_print_temperature: 260
   min_bed_temperature: 0
   max_bed_temperature: 80
+  drying_temperature: 65
+  drying_time: 360
 url: https://addnorth.com/product/PETG/PETG%20-%201.75mm%20-%20750g%20-%20Red

--- a/data/materials/addnorth/addnorth-rpetg-matte-black.yaml
+++ b/data/materials/addnorth/addnorth-rpetg-matte-black.yaml
@@ -18,3 +18,5 @@ properties:
   max_print_temperature: 260
   min_bed_temperature: 0
   max_bed_temperature: 80
+  drying_temperature: 65
+  drying_time: 360

--- a/data/materials/addnorth/addnorth-rpetg-matte-grey.yaml
+++ b/data/materials/addnorth/addnorth-rpetg-matte-grey.yaml
@@ -20,4 +20,6 @@ properties:
   max_print_temperature: 260
   min_bed_temperature: 0
   max_bed_temperature: 80
+  drying_temperature: 65
+  drying_time: 360
 url: https://addnorth.com/product/rPETG%20Matte/rPETG%20Matte%20-%201.75mm%20-%201000g%20-%20Grey

--- a/data/materials/addnorth/addnorth-rpetg-matte-white.yaml
+++ b/data/materials/addnorth/addnorth-rpetg-matte-white.yaml
@@ -18,6 +18,8 @@ properties:
   max_print_temperature: 260
   min_bed_temperature: 0
   max_bed_temperature: 80
+  drying_temperature: 65
+  drying_time: 360
 photos:
 - url: https://files.openprinttag.org/addnorth/addnorth-rpetg-matte-white/addnorth-rpetg-matte-white-0-67add47d.png
   type: unspecified


### PR DESCRIPTION
added below properties:
  drying_temperature: 65
  drying_time: 360

Data collected from below:
https://addnorth.com/knowledge/articles/petg-print-guide
