### PR TITLE
Fixed tags - Removed industrially_compostable from PLA+CF/GF materials

### DIFF
--- a/data/materials/3dxtech/3dxtech-carbonx-placf.yaml
+++ b/data/materials/3dxtech/3dxtech-carbonx-placf.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/3dxtech/3dxtech-carbonx-placf/bc4d1bf9983e.png
-  type: unspecified
+  - url: https://files.openprinttag.org/3dxtech/3dxtech-carbonx-placf/bc4d1bf9983e.png
+    type: unspecified
 properties: {}

--- a/data/materials/amolen/amolen-pla-carbon-fiber-aquamarine-blue.yaml
+++ b/data/materials/amolen/amolen-pla-carbon-fiber-aquamarine-blue.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#2a4552ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-aquamarine-blue/1d672370d679.png
-  type: unspecified
+  - url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-aquamarine-blue/1d672370d679.png
+    type: unspecified
 properties: {}

--- a/data/materials/amolen/amolen-pla-carbon-fiber-black.yaml
+++ b/data/materials/amolen/amolen-pla-carbon-fiber-black.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-black/6a46e4c796e0.png
-  type: unspecified
+  - url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-black/6a46e4c796e0.png
+    type: unspecified
 properties: {}

--- a/data/materials/amolen/amolen-pla-carbon-fiber-brown.yaml
+++ b/data/materials/amolen/amolen-pla-carbon-fiber-brown.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#ae9d7eff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-brown/391e9a66935b.png
-  type: unspecified
+  - url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-brown/391e9a66935b.png
+    type: unspecified
 properties: {}

--- a/data/materials/amolen/amolen-pla-carbon-fiber-burgundy.yaml
+++ b/data/materials/amolen/amolen-pla-carbon-fiber-burgundy.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#833f4dff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-burgundy/b58305be01d1.png
-  type: unspecified
+  - url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-burgundy/b58305be01d1.png
+    type: unspecified
 properties: {}

--- a/data/materials/amolen/amolen-pla-carbon-fiber-dark-grey.yaml
+++ b/data/materials/amolen/amolen-pla-carbon-fiber-dark-grey.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#5a696cff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-dark-grey/b13a518a5432.png
-  type: unspecified
+  - url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-dark-grey/b13a518a5432.png
+    type: unspecified
 properties: {}

--- a/data/materials/amolen/amolen-pla-carbon-fiber-green.yaml
+++ b/data/materials/amolen/amolen-pla-carbon-fiber-green.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#656d60ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-green/0b9564459bee.png
-  type: unspecified
+  - url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-green/0b9564459bee.png
+    type: unspecified
 properties: {}

--- a/data/materials/amolen/amolen-pla-carbon-fiber-light-grey.yaml
+++ b/data/materials/amolen/amolen-pla-carbon-fiber-light-grey.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#a2aaadff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-light-grey/9acf62d4ecda.png
-  type: unspecified
+  - url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-light-grey/9acf62d4ecda.png
+    type: unspecified
 properties: {}

--- a/data/materials/amolen/amolen-pla-carbon-fiber-sapphire-blue.yaml
+++ b/data/materials/amolen/amolen-pla-carbon-fiber-sapphire-blue.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#375680ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-sapphire-blue/556100e06b00.png
-  type: unspecified
+  - url: https://files.openprinttag.org/amolen/amolen-pla-carbon-fiber-sapphire-blue/556100e06b00.png
+    type: unspecified
 properties: {}

--- a/data/materials/anycubic/anycubic-pla-cf-black.yaml
+++ b/data/materials/anycubic/anycubic-pla-cf-black.yaml
@@ -10,13 +10,12 @@ url: https://store.anycubic.com/products/pla-cf-filament?variant=46679783866530
 primary_color:
   color_rgba: '#212322ff'
 tags:
-- matte
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - matte
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties:
   density: 1.22
 photos:
-- url: https://files.openprinttag.org/anycubic/anycubic-pla-cf-black/anycubic-pla-cf-black-0-182383f1.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/anycubic/anycubic-pla-cf-black/anycubic-pla-cf-black-0-182383f1.jpg
+    type: unspecified

--- a/data/materials/anycubic/anycubic-pla-cf-cowboy-blue.yaml
+++ b/data/materials/anycubic/anycubic-pla-cf-cowboy-blue.yaml
@@ -10,13 +10,12 @@ url: https://store.anycubic.com/products/pla-cf-filament?_sasdk=dMTk4MDgyYmJhMDg
 primary_color:
   color_rgba: '#6987bcff'
 tags:
-- matte
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - matte
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties:
   density: 1.22
 photos:
-- url: https://files.openprinttag.org/anycubic/anycubic-pla-cf-cowboy-blue/anycubic-pla-cf-cowboy-blue-0-8596e3da.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/anycubic/anycubic-pla-cf-cowboy-blue/anycubic-pla-cf-cowboy-blue-0-8596e3da.jpg
+    type: unspecified

--- a/data/materials/anycubic/anycubic-pla-cf-fish-scale-white.yaml
+++ b/data/materials/anycubic/anycubic-pla-cf-fish-scale-white.yaml
@@ -10,13 +10,12 @@ url: https://store.anycubic.com/products/pla-cf-filament?variant=46683423998114
 primary_color:
   color_rgba: '#bfbfc3ff'
 tags:
-- matte
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - matte
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties:
   density: 1.22
 photos:
-- url: https://files.openprinttag.org/anycubic/anycubic-pla-cf-fish-scale-white/anycubic-pla-cf-fish-scale-white-0-2fd582cd.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/anycubic/anycubic-pla-cf-fish-scale-white/anycubic-pla-cf-fish-scale-white-0-2fd582cd.jpg
+    type: unspecified

--- a/data/materials/anycubic/anycubic-pla-cf-jade-green.yaml
+++ b/data/materials/anycubic/anycubic-pla-cf-jade-green.yaml
@@ -10,13 +10,12 @@ url: https://store.anycubic.com/products/pla-cf-filament?variant=46683424129186
 primary_color:
   color_rgba: '#18332fff'
 tags:
-- matte
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - matte
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties:
   density: 1.22
 photos:
-- url: https://files.openprinttag.org/anycubic/anycubic-pla-cf-jade-green/anycubic-pla-cf-jade-green-0-004fc75f.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/anycubic/anycubic-pla-cf-jade-green/anycubic-pla-cf-jade-green-0-004fc75f.jpg
+    type: unspecified

--- a/data/materials/anycubic/anycubic-pla-cf-lava-grey.yaml
+++ b/data/materials/anycubic/anycubic-pla-cf-lava-grey.yaml
@@ -10,13 +10,12 @@ url: https://store.anycubic.com/products/pla-cf-filament?variant=46679783735458
 primary_color:
   color_rgba: '#4e5055ff'
 tags:
-- matte
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - matte
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties:
   density: 1.22
 photos:
-- url: https://files.openprinttag.org/anycubic/anycubic-pla-cf-lava-grey/anycubic-pla-cf-lava-grey-0-a37f2032.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/anycubic/anycubic-pla-cf-lava-grey/anycubic-pla-cf-lava-grey-0-a37f2032.jpg
+    type: unspecified

--- a/data/materials/anycubic/anycubic-pla-cf-vintage-red.yaml
+++ b/data/materials/anycubic/anycubic-pla-cf-vintage-red.yaml
@@ -10,13 +10,12 @@ url: https://store.anycubic.com/products/pla-cf-filament?variant=46679783473314
 primary_color:
   color_rgba: '#862633ff'
 tags:
-- matte
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - matte
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties:
   density: 1.22
 photos:
-- url: https://files.openprinttag.org/anycubic/anycubic-pla-cf-vintage-red/anycubic-pla-cf-vintage-red-0-1524b1fe.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/anycubic/anycubic-pla-cf-vintage-red/anycubic-pla-cf-vintage-red-0-1524b1fe.jpg
+    type: unspecified

--- a/data/materials/arianeplast/arianeplast-pla-carbon.yaml
+++ b/data/materials/arianeplast/arianeplast-pla-carbon.yaml
@@ -10,7 +10,6 @@ url: https://www.arianeplast.com/en/filaments-carbone/2907-pla-carbone-8kg-3d-fi
 primary_color:
   color_rgba: '#45444aff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/atomic-filament/atomic-filament-carbon-fiber-extreme-black-pla.yaml
+++ b/data/materials/atomic-filament/atomic-filament-carbon-fiber-extreme-black-pla.yaml
@@ -10,10 +10,9 @@ url: https://atomicfilament.com/products/carbon-fiber-extreme-pla-filament
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/atomic-filament/atomic-filament-carbon-fiber-extreme-black-pla/0251ed3ab9c8.png
-  type: unspecified
+  - url: https://files.openprinttag.org/atomic-filament/atomic-filament-carbon-fiber-extreme-black-pla/0251ed3ab9c8.png
+    type: unspecified
 properties: {}

--- a/data/materials/bambulab/bambulab-pla-cf-black.yaml
+++ b/data/materials/bambulab/bambulab-pla-cf-black.yaml
@@ -12,7 +12,6 @@ tags:
   - contains_carbon_fiber
   - abrasive
   - contains_carbon
-  - industrially_compostable
 photos:
   - url: https://files.openprinttag.org/bambulab/bambulab-pla-cf-black/03c0b3e36ca5.png
     type: unspecified

--- a/data/materials/bambulab/bambulab-pla-cf-burgundy-red.yaml
+++ b/data/materials/bambulab/bambulab-pla-cf-burgundy-red.yaml
@@ -12,7 +12,6 @@ tags:
   - contains_carbon_fiber
   - abrasive
   - contains_carbon
-  - industrially_compostable
 photos:
   - url: https://files.openprinttag.org/bambulab/bambulab-pla-cf-burgundy-red/a43dc047f7b5.png
     type: unspecified

--- a/data/materials/bambulab/bambulab-pla-cf-iris-purple.yaml
+++ b/data/materials/bambulab/bambulab-pla-cf-iris-purple.yaml
@@ -12,7 +12,6 @@ tags:
   - contains_carbon_fiber
   - abrasive
   - contains_carbon
-  - industrially_compostable
 photos:
   - url: https://files.openprinttag.org/bambulab/bambulab-pla-cf-iris-purple/6f3ec397c647.png
     type: unspecified

--- a/data/materials/bambulab/bambulab-pla-cf-jeans-blue.yaml
+++ b/data/materials/bambulab/bambulab-pla-cf-jeans-blue.yaml
@@ -12,7 +12,6 @@ tags:
   - contains_carbon_fiber
   - abrasive
   - contains_carbon
-  - industrially_compostable
 photos:
   - url: https://files.openprinttag.org/bambulab/bambulab-pla-cf-jeans-blue/002c160e3713.png
     type: unspecified

--- a/data/materials/bambulab/bambulab-pla-cf-lava-gray.yaml
+++ b/data/materials/bambulab/bambulab-pla-cf-lava-gray.yaml
@@ -12,7 +12,6 @@ tags:
   - contains_carbon_fiber
   - abrasive
   - contains_carbon
-  - industrially_compostable
 photos:
   - url: https://files.openprinttag.org/bambulab/bambulab-pla-cf-lava-gray/3eb60493d100.png
     type: unspecified

--- a/data/materials/bambulab/bambulab-pla-cf-matcha-green.yaml
+++ b/data/materials/bambulab/bambulab-pla-cf-matcha-green.yaml
@@ -12,7 +12,6 @@ tags:
   - contains_carbon_fiber
   - abrasive
   - contains_carbon
-  - industrially_compostable
 photos:
   - url: https://files.openprinttag.org/bambulab/bambulab-pla-cf-matcha-green/0644698b0ee1.png
     type: unspecified

--- a/data/materials/bambulab/bambulab-pla-cf-royal-blue.yaml
+++ b/data/materials/bambulab/bambulab-pla-cf-royal-blue.yaml
@@ -12,7 +12,6 @@ tags:
   - contains_carbon_fiber
   - abrasive
   - contains_carbon
-  - industrially_compostable
 photos:
   - url: https://files.openprinttag.org/bambulab/bambulab-pla-cf-royal-blue/9c08036ab819.png
     type: unspecified

--- a/data/materials/creality/creality-carbon-fiber-pla-black.yaml
+++ b/data/materials/creality/creality-carbon-fiber-pla-black.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/creality/creality-carbon-fiber-pla-black/826059279504.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/creality/creality-carbon-fiber-pla-black/826059279504.jpg
+    type: unspecified
 properties: {}

--- a/data/materials/elegoo/elegoo-pla-cf-black.yaml
+++ b/data/materials/elegoo/elegoo-pla-cf-black.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/elegoo/elegoo-pla-cf-black/1169ff614a2d.png
-  type: unspecified
+  - url: https://files.openprinttag.org/elegoo/elegoo-pla-cf-black/1169ff614a2d.png
+    type: unspecified
 properties: {}

--- a/data/materials/esun/esun-carbon-fiber-pla-black.yaml
+++ b/data/materials/esun/esun-carbon-fiber-pla-black.yaml
@@ -14,7 +14,6 @@ tags:
   - contains_carbon_fiber
   - abrasive
   - contains_carbon
-  - industrially_compostable
 properties: {}
 photos:
   - url: https://files.openprinttag.org/esun/esun-carbon-fiber-pla-black/835f37be5fb2.jpg

--- a/data/materials/esun/esun-carbon-fiber-pla-brown.yaml
+++ b/data/materials/esun/esun-carbon-fiber-pla-brown.yaml
@@ -14,7 +14,6 @@ tags:
   - contains_carbon_fiber
   - abrasive
   - contains_carbon
-  - industrially_compostable
 properties: {}
 photos:
   - url: https://files.openprinttag.org/esun/esun-carbon-fiber-pla-brown/903d4931472e.jpg

--- a/data/materials/esun/esun-carbon-fiber-pla-green.yaml
+++ b/data/materials/esun/esun-carbon-fiber-pla-green.yaml
@@ -14,7 +14,6 @@ tags:
   - contains_carbon_fiber
   - abrasive
   - contains_carbon
-  - industrially_compostable
 properties: {}
 photos:
   - url: https://files.openprinttag.org/esun/esun-carbon-fiber-pla-green/309da3dcbab0.jpg

--- a/data/materials/esun/esun-carbon-fiber-pla-purple.yaml
+++ b/data/materials/esun/esun-carbon-fiber-pla-purple.yaml
@@ -14,7 +14,6 @@ tags:
   - contains_carbon_fiber
   - abrasive
   - contains_carbon
-  - industrially_compostable
 properties: {}
 photos:
   - url: https://files.openprinttag.org/esun/esun-carbon-fiber-pla-purple/352ed8ffa118.jpg

--- a/data/materials/esun/esun-carbon-fiber-pla-red.yaml
+++ b/data/materials/esun/esun-carbon-fiber-pla-red.yaml
@@ -14,7 +14,6 @@ tags:
   - contains_carbon_fiber
   - abrasive
   - contains_carbon
-  - industrially_compostable
 properties: {}
 photos:
   - url: https://files.openprinttag.org/esun/esun-carbon-fiber-pla-red/8451fe2b3261.jpg

--- a/data/materials/fiberthree/fiberthree-f3-pla-gf.yaml
+++ b/data/materials/fiberthree/fiberthree-f3-pla-gf.yaml
@@ -10,7 +10,6 @@ url: https://www.fiberthree.com/filaments#F3PC
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_glass_fiber
-- abrasive
-- industrially_compostable
+  - contains_glass_fiber
+  - abrasive
 properties: {}

--- a/data/materials/filamentree/filamentree-pla-cf-black.yaml
+++ b/data/materials/filamentree/filamentree-pla-cf-black.yaml
@@ -10,8 +10,7 @@ url: https://www.filamentree.eu/shop/30710471-pla-cf-black-1kg-5060?category=62#
 primary_color:
   color_rgba: '#24292aff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties:
   density: 1.24

--- a/data/materials/flashforge/flashforge-pla-cf-black.yaml
+++ b/data/materials/flashforge/flashforge-pla-cf-black.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/flashforge/flashforge-pla-cf-black/acb0f6d434d7.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/flashforge/flashforge-pla-cf-black/acb0f6d434d7.jpg
+    type: unspecified
 properties: {}

--- a/data/materials/flashforge/flashforge-pla-cf-dusty-pink.yaml
+++ b/data/materials/flashforge/flashforge-pla-cf-dusty-pink.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#795b65ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/flashforge/flashforge-pla-cf-dusty-pink/3a916e332e5d.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/flashforge/flashforge-pla-cf-dusty-pink/3a916e332e5d.jpg
+    type: unspecified
 properties: {}

--- a/data/materials/flashforge/flashforge-pla-cf-iris-purple.yaml
+++ b/data/materials/flashforge/flashforge-pla-cf-iris-purple.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#663d7eff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/flashforge/flashforge-pla-cf-iris-purple/524e85af04c2.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/flashforge/flashforge-pla-cf-iris-purple/524e85af04c2.jpg
+    type: unspecified
 properties: {}

--- a/data/materials/flashforge/flashforge-pla-cf-marsala.yaml
+++ b/data/materials/flashforge/flashforge-pla-cf-marsala.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#6e485fff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/flashforge/flashforge-pla-cf-marsala/c94eaab721ec.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/flashforge/flashforge-pla-cf-marsala/c94eaab721ec.jpg
+    type: unspecified
 properties: {}

--- a/data/materials/flashforge/flashforge-pla-cf-midnight-blue.yaml
+++ b/data/materials/flashforge/flashforge-pla-cf-midnight-blue.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#282d42ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/flashforge/flashforge-pla-cf-midnight-blue/2abdc8cbcf31.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/flashforge/flashforge-pla-cf-midnight-blue/2abdc8cbcf31.jpg
+    type: unspecified
 properties: {}

--- a/data/materials/flashforge/flashforge-pla-cf-sailor-blue.yaml
+++ b/data/materials/flashforge/flashforge-pla-cf-sailor-blue.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#4d6383ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/flashforge/flashforge-pla-cf-sailor-blue/9e84e09ef78b.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/flashforge/flashforge-pla-cf-sailor-blue/9e84e09ef78b.jpg
+    type: unspecified
 properties: {}

--- a/data/materials/flashforge/flashforge-pla-cf-volcanic-rock-gray.yaml
+++ b/data/materials/flashforge/flashforge-pla-cf-volcanic-rock-gray.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#26272bff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/flashforge/flashforge-pla-cf-volcanic-rock-gray/107ba26a2b3a.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/flashforge/flashforge-pla-cf-volcanic-rock-gray/107ba26a2b3a.jpg
+    type: unspecified
 properties: {}

--- a/data/materials/geeetech/geeetech-pla-carbon-fiber-blue.yaml
+++ b/data/materials/geeetech/geeetech-pla-carbon-fiber-blue.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#232834ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/geeetech/geeetech-pla-carbon-fiber-blue/c556bf138016.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/geeetech/geeetech-pla-carbon-fiber-blue/c556bf138016.jpg
+    type: unspecified
 properties: {}

--- a/data/materials/geeetech/geeetech-pla-cf-brick-red.yaml
+++ b/data/materials/geeetech/geeetech-pla-cf-brick-red.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#462b2eff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/geeetech/geeetech-pla-cf-brick-red/becd9e4387bc.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/geeetech/geeetech-pla-cf-brick-red/becd9e4387bc.jpg
+    type: unspecified
 properties: {}

--- a/data/materials/geeetech/geeetech-pla-cf-matcha-green.yaml
+++ b/data/materials/geeetech/geeetech-pla-cf-matcha-green.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#363c32ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/geeetech/geeetech-pla-cf-matcha-green/58c40c6b1ecb.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/geeetech/geeetech-pla-cf-matcha-green/58c40c6b1ecb.jpg
+    type: unspecified
 properties: {}

--- a/data/materials/hatchbox/hatchbox-carbon-fiber-pla.yaml
+++ b/data/materials/hatchbox/hatchbox-carbon-fiber-pla.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#1d1d1dff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/hatchbox/hatchbox-carbon-fiber-pla/812b635c8680.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/hatchbox/hatchbox-carbon-fiber-pla/812b635c8680.jpg
+    type: unspecified
 properties: {}

--- a/data/materials/kingroon/kingroon-pla-carbon-fiber-basic.yaml
+++ b/data/materials/kingroon/kingroon-pla-carbon-fiber-basic.yaml
@@ -10,7 +10,6 @@ url: https://kingroon.com/products/kingroon-pla-carbon-fiber-basic-3d-printer-fi
 primary_color:
   color_rgba: '#292824ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/matter3d-inc/matter3d-inc-basics-series-pla-carbon-fiber-black.yaml
+++ b/data/materials/matter3d-inc/matter3d-inc-basics-series-pla-carbon-fiber-black.yaml
@@ -10,7 +10,6 @@ url: https://www.matter3d.com/collections/pla-filament/products/carbon-fiber-pla
 primary_color:
   color_rgba: '#232323ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/mexico-makers/mexico-makers-pla-cf-negro.yaml
+++ b/data/materials/mexico-makers/mexico-makers-pla-cf-negro.yaml
@@ -12,5 +12,4 @@ primary_color:
 tags:
   - contains_carbon_fiber
   - abrasive
-  - industrially_compostable
 properties: {}

--- a/data/materials/nobufil/nobufil-plax-cf-black.yaml
+++ b/data/materials/nobufil/nobufil-plax-cf-black.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/nobufil/nobufil-plax-cf-black/c9ef9d1ef6eb.png
-  type: unspecified
+  - url: https://files.openprinttag.org/nobufil/nobufil-plax-cf-black/c9ef9d1ef6eb.png
+    type: unspecified
 properties: {}

--- a/data/materials/numakers/numakers-pla-cf-black.yaml
+++ b/data/materials/numakers/numakers-pla-cf-black.yaml
@@ -10,11 +10,10 @@ url: https://numakers.com/products/pla-cf?variant=48035623731508
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties: {}
 photos:
-- url: https://files.openprinttag.org/numakers/numakers-pla-cf-black/numakers-pla-cf-black-0-1997b2d8.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/numakers/numakers-pla-cf-black/numakers-pla-cf-black-0-1997b2d8.jpg
+    type: unspecified

--- a/data/materials/numakers/numakers-pla-cf-denim-blue.yaml
+++ b/data/materials/numakers/numakers-pla-cf-denim-blue.yaml
@@ -10,11 +10,10 @@ url: https://numakers.com/products/pla-cf?variant=48462471299380
 primary_color:
   color_rgba: '#5e84a4ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties: {}
 photos:
-- url: https://files.openprinttag.org/numakers/numakers-pla-cf-denim-blue/numakers-pla-cf-denim-blue-0-7b96c91e.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/numakers/numakers-pla-cf-denim-blue/numakers-pla-cf-denim-blue-0-7b96c91e.jpg
+    type: unspecified

--- a/data/materials/numakers/numakers-pla-cf-lemongrass-green.yaml
+++ b/data/materials/numakers/numakers-pla-cf-lemongrass-green.yaml
@@ -10,11 +10,10 @@ url: https://numakers.com/products/pla-cf?variant=48462471332148
 primary_color:
   color_rgba: '#66875eff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties: {}
 photos:
-- url: https://files.openprinttag.org/numakers/numakers-pla-cf-lemongrass-green/numakers-pla-cf-lemongrass-green-0-c9da9e90.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/numakers/numakers-pla-cf-lemongrass-green/numakers-pla-cf-lemongrass-green-0-c9da9e90.jpg
+    type: unspecified

--- a/data/materials/numakers/numakers-pla-cf-wine-red.yaml
+++ b/data/materials/numakers/numakers-pla-cf-wine-red.yaml
@@ -10,11 +10,10 @@ url: https://numakers.com/products/pla-cf?variant=48348442231092
 primary_color:
   color_rgba: '#80464fff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties: {}
 photos:
-- url: https://files.openprinttag.org/numakers/numakers-pla-cf-wine-red/numakers-pla-cf-wine-red-0-91e1b87e.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/numakers/numakers-pla-cf-wine-red/numakers-pla-cf-wine-red-0-91e1b87e.jpg
+    type: unspecified

--- a/data/materials/overture/overture-pla-carbon-fiber-midnight-black.yaml
+++ b/data/materials/overture/overture-pla-carbon-fiber-midnight-black.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/overture/overture-pla-carbon-fiber-midnight-black/7f7d24b81b58.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/overture/overture-pla-carbon-fiber-midnight-black/7f7d24b81b58.jpg
+    type: unspecified
 properties: {}

--- a/data/materials/polymaker/polymaker-polylite-pla-cf-black.yaml
+++ b/data/materials/polymaker/polymaker-polylite-pla-cf-black.yaml
@@ -12,7 +12,6 @@ tags:
   - contains_carbon_fiber
   - abrasive
   - contains_carbon
-  - industrially_compostable
 photos:
   - url: https://files.openprinttag.org/polymaker/polymaker-polylite-pla-cf-black/f65486eeeb1b.png
     type: unspecified

--- a/data/materials/primacreator/primacreator-primaselect-pla-carbon-blue.yaml
+++ b/data/materials/primacreator/primacreator-primaselect-pla-carbon-blue.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#033877ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/primacreator/primacreator-primaselect-pla-carbon-blue/381726c13a49.png
-  type: unspecified
+  - url: https://files.openprinttag.org/primacreator/primacreator-primaselect-pla-carbon-blue/381726c13a49.png
+    type: unspecified
 properties: {}

--- a/data/materials/primacreator/primacreator-primaselect-pla-carbon-dark-brown.yaml
+++ b/data/materials/primacreator/primacreator-primaselect-pla-carbon-dark-brown.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#6e4325ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/primacreator/primacreator-primaselect-pla-carbon-dark-brown/b328bfd227a7.png
-  type: unspecified
+  - url: https://files.openprinttag.org/primacreator/primacreator-primaselect-pla-carbon-dark-brown/b328bfd227a7.png
+    type: unspecified
 properties: {}

--- a/data/materials/primacreator/primacreator-primaselect-pla-carbon-dark-green.yaml
+++ b/data/materials/primacreator/primacreator-primaselect-pla-carbon-dark-green.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#165158ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/primacreator/primacreator-primaselect-pla-carbon-dark-green/8096b8bc3b4c.png
-  type: unspecified
+  - url: https://files.openprinttag.org/primacreator/primacreator-primaselect-pla-carbon-dark-green/8096b8bc3b4c.png
+    type: unspecified
 properties: {}

--- a/data/materials/primacreator/primacreator-primaselect-pla-cf-black.yaml
+++ b/data/materials/primacreator/primacreator-primaselect-pla-cf-black.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/primacreator/primacreator-primaselect-pla-cf-black/8cb07fc5818d.png
-  type: unspecified
+  - url: https://files.openprinttag.org/primacreator/primacreator-primaselect-pla-cf-black/8cb07fc5818d.png
+    type: unspecified
 properties: {}

--- a/data/materials/print-with-smile/print-with-smile-pla-uvht-c15.yaml
+++ b/data/materials/print-with-smile/print-with-smile-pla-uvht-c15.yaml
@@ -10,7 +10,6 @@ url: https://printwithsmile.cz/gb/3d-filamenty/393-pla-uvht-c15-500-g-8594196459
 primary_color:
   color_rgba: '#2a3940ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/printedsolid/printedsolid-ps-imports-pla-special-series-carbon-fiber.yaml
+++ b/data/materials/printedsolid/printedsolid-ps-imports-pla-special-series-carbon-fiber.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/printedsolid/printedsolid-ps-imports-pla-special-series-carbon-fiber/af7ebc19df2b.png
-  type: unspecified
+  - url: https://files.openprinttag.org/printedsolid/printedsolid-ps-imports-pla-special-series-carbon-fiber/af7ebc19df2b.png
+    type: unspecified
 properties: {}

--- a/data/materials/protopasta/protopasta-black-carbon-fiber-composite-htpla.yaml
+++ b/data/materials/protopasta/protopasta-black-carbon-fiber-composite-htpla.yaml
@@ -9,11 +9,10 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- high_temperature
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - high_temperature
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/protopasta/protopasta-black-carbon-fiber-composite-htpla/d527fd399b9f.png
-  type: unspecified
+  - url: https://files.openprinttag.org/protopasta/protopasta-black-carbon-fiber-composite-htpla/d527fd399b9f.png
+    type: unspecified
 properties: {}

--- a/data/materials/protopasta/protopasta-dark-gray-carbon-fiber-composite-htpla.yaml
+++ b/data/materials/protopasta/protopasta-dark-gray-carbon-fiber-composite-htpla.yaml
@@ -9,11 +9,10 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#394658ff'
 tags:
-- contains_carbon_fiber
-- high_temperature
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - high_temperature
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/protopasta/protopasta-dark-gray-carbon-fiber-composite-htpla/dc14712916f0.png
-  type: unspecified
+  - url: https://files.openprinttag.org/protopasta/protopasta-dark-gray-carbon-fiber-composite-htpla/dc14712916f0.png
+    type: unspecified
 properties: {}

--- a/data/materials/protopasta/protopasta-light-gray-carbon-fiber-composite-htpla.yaml
+++ b/data/materials/protopasta/protopasta-light-gray-carbon-fiber-composite-htpla.yaml
@@ -9,11 +9,10 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#bac4c4ff'
 tags:
-- contains_carbon_fiber
-- high_temperature
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - high_temperature
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/protopasta/protopasta-light-gray-carbon-fiber-composite-htpla/809ebcdf7065.png
-  type: unspecified
+  - url: https://files.openprinttag.org/protopasta/protopasta-light-gray-carbon-fiber-composite-htpla/809ebcdf7065.png
+    type: unspecified
 properties: {}

--- a/data/materials/protopasta/protopasta-recycled-carbon-fiber-pla.yaml
+++ b/data/materials/protopasta/protopasta-recycled-carbon-fiber-pla.yaml
@@ -9,11 +9,10 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- recycled
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - recycled
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/protopasta/protopasta-recycled-carbon-fiber-pla/55602ad94a34.png
-  type: unspecified
+  - url: https://files.openprinttag.org/protopasta/protopasta-recycled-carbon-fiber-pla/55602ad94a34.png
+    type: unspecified
 properties: {}

--- a/data/materials/protopasta/protopasta-static-dissipative-carbon-fiber-pla.yaml
+++ b/data/materials/protopasta/protopasta-static-dissipative-carbon-fiber-pla.yaml
@@ -9,11 +9,10 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- esd_safe
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - esd_safe
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/protopasta/protopasta-static-dissipative-carbon-fiber-pla/d05601a6ad8a.png
-  type: unspecified
+  - url: https://files.openprinttag.org/protopasta/protopasta-static-dissipative-carbon-fiber-pla/d05601a6ad8a.png
+    type: unspecified
 properties: {}

--- a/data/materials/protopasta/protopasta-the-original-carbon-fiber-composite-pla.yaml
+++ b/data/materials/protopasta/protopasta-the-original-carbon-fiber-composite-pla.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/protopasta/protopasta-the-original-carbon-fiber-composite-pla/097842c2eb99.png
-  type: unspecified
+  - url: https://files.openprinttag.org/protopasta/protopasta-the-original-carbon-fiber-composite-pla/097842c2eb99.png
+    type: unspecified
 properties: {}

--- a/data/materials/qidi/qidi-pla-cf-black.yaml
+++ b/data/materials/qidi/qidi-pla-cf-black.yaml
@@ -10,11 +10,10 @@ url: https://us.qidi3d.com/products/pla-cf?variant=50737678188864
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties: {}
 photos:
-- url: https://files.openprinttag.org/qidi/qidi-pla-cf-black/qidi-pla-cf-black-0-eba5ca5a.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/qidi/qidi-pla-cf-black/qidi-pla-cf-black-0-eba5ca5a.jpg
+    type: unspecified

--- a/data/materials/qidi/qidi-pla-cf-dark-red.yaml
+++ b/data/materials/qidi/qidi-pla-cf-dark-red.yaml
@@ -10,11 +10,10 @@ url: https://us.qidi3d.com/products/pla-cf?variant=50737678221632
 primary_color:
   color_rgba: '#9a5c6bff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties: {}
 photos:
-- url: https://files.openprinttag.org/qidi/qidi-pla-cf-dark-red/qidi-pla-cf-dark-red-0-d96e9fa9.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/qidi/qidi-pla-cf-dark-red/qidi-pla-cf-dark-red-0-d96e9fa9.jpg
+    type: unspecified

--- a/data/materials/qidi/qidi-pla-cf-lavender-purple.yaml
+++ b/data/materials/qidi/qidi-pla-cf-lavender-purple.yaml
@@ -10,11 +10,10 @@ url: https://us.qidi3d.com/products/pla-cf?variant=50737678287168
 primary_color:
   color_rgba: '#660066ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties: {}
 photos:
-- url: https://files.openprinttag.org/qidi/qidi-pla-cf-lavender-purple/qidi-pla-cf-lavender-purple-0-c667b7a0.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/qidi/qidi-pla-cf-lavender-purple/qidi-pla-cf-lavender-purple-0-c667b7a0.jpg
+    type: unspecified

--- a/data/materials/qidi/qidi-pla-cf-midnight-blue.yaml
+++ b/data/materials/qidi/qidi-pla-cf-midnight-blue.yaml
@@ -10,11 +10,10 @@ url: https://us.qidi3d.com/products/pla-cf?variant=50737678319936
 primary_color:
   color_rgba: '#566b8fff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties: {}
 photos:
-- url: https://files.openprinttag.org/qidi/qidi-pla-cf-midnight-blue/qidi-pla-cf-midnight-blue-0-967f74a1.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/qidi/qidi-pla-cf-midnight-blue/qidi-pla-cf-midnight-blue-0-967f74a1.jpg
+    type: unspecified

--- a/data/materials/qidi/qidi-pla-cf-olive-green.yaml
+++ b/data/materials/qidi/qidi-pla-cf-olive-green.yaml
@@ -10,11 +10,10 @@ url: https://us.qidi3d.com/products/pla-cf?variant=50737678254400
 primary_color:
   color_rgba: '#67785aff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- contains_carbon
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
+  - contains_carbon
 properties: {}
 photos:
-- url: https://files.openprinttag.org/qidi/qidi-pla-cf-olive-green/qidi-pla-cf-olive-green-0-76bda40f.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/qidi/qidi-pla-cf-olive-green/qidi-pla-cf-olive-green-0-76bda40f.jpg
+    type: unspecified

--- a/data/materials/rosa3d-filaments/rosa3d-filaments-pla-carbonlook.yaml
+++ b/data/materials/rosa3d-filaments/rosa3d-filaments-pla-carbonlook.yaml
@@ -10,7 +10,6 @@ url: https://www.rosa3d.pl/en/filament-3d-pla-carbonlook
 primary_color:
   color_rgba: '#292824ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-avocado-guacamole.yaml
+++ b/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-avocado-guacamole.yaml
@@ -10,8 +10,7 @@ url: https://www.rosa3d.pl/en/filament-3d-refill-pla-cf-matt-avocado-guacamole-1
 primary_color:
   color_rgba: '#70a641ff'
 tags:
-- matte
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - matte
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-blue-jeans.yaml
+++ b/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-blue-jeans.yaml
@@ -10,8 +10,7 @@ url: https://www.rosa3d.pl/en/filament-3d-refill-pla-cf-matt-blue-jeans-175mm-1k
 primary_color:
   color_rgba: '#9db6d4ff'
 tags:
-- contains_carbon_fiber
-- matte
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - matte
+  - abrasive
 properties: {}

--- a/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-carbon-black.yaml
+++ b/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-carbon-black.yaml
@@ -10,8 +10,7 @@ url: https://www.rosa3d.pl/en/3d-filament-refill-pla-cf-matt-carbon-black-1kg
 primary_color:
   color_rgba: '#3e413fff'
 tags:
-- matte
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - matte
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-fired-brick.yaml
+++ b/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-fired-brick.yaml
@@ -10,8 +10,7 @@ url: https://www.rosa3d.pl/en/filament-3d-refill-pla-cf-matt-fired-brick-1kg
 primary_color:
   color_rgba: '#8b3a3aff'
 tags:
-- matte
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - matte
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-grape-violet.yaml
+++ b/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-grape-violet.yaml
@@ -10,8 +10,7 @@ url: https://www.rosa3d.pl/en/filament-3d-refill-pla-cf-matt-grape-violet-175mm-
 primary_color:
   color_rgba: '#8d5984ff'
 tags:
-- matte
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - matte
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-hibiscus-pink.yaml
+++ b/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-hibiscus-pink.yaml
@@ -10,8 +10,7 @@ url: https://www.rosa3d.pl/en/filament-3d-refill-pla-cf-matt-hibiscus-pink-1kg
 primary_color:
   color_rgba: '#bf5a6bff'
 tags:
-- matte
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - matte
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-lava-gray.yaml
+++ b/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-lava-gray.yaml
@@ -10,8 +10,7 @@ url: https://www.rosa3d.pl/en/filament-3d-refill-pla-cf-matt-lava-gray-175mm-1kg
 primary_color:
   color_rgba: '#595959ff'
 tags:
-- contains_carbon_fiber
-- matte
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - matte
+  - abrasive
 properties: {}

--- a/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-matcha-green.yaml
+++ b/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-matcha-green.yaml
@@ -10,8 +10,7 @@ url: https://www.rosa3d.pl/en/filament-3d-refill-pla-cf-matt-matcha-green-175mm-
 primary_color:
   color_rgba: '#3d9441ff'
 tags:
-- matte
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - matte
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-olive-brown.yaml
+++ b/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-olive-brown.yaml
@@ -10,8 +10,7 @@ url: https://www.rosa3d.pl/en/filament-3d-refill-pla-cf-matt-olive-brown-175mm-1
 primary_color:
   color_rgba: '#837e68ff'
 tags:
-- contains_carbon_fiber
-- matte
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - matte
+  - abrasive
 properties: {}

--- a/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-olive-green.yaml
+++ b/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-olive-green.yaml
@@ -10,8 +10,7 @@ url: https://www.rosa3d.pl/en/filament-3d-refill-pla-cf-matt-olive-green-175mm-1
 primary_color:
   color_rgba: '#748c45ff'
 tags:
-- matte
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - matte
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-stone-cold-gray.yaml
+++ b/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-stone-cold-gray.yaml
@@ -10,8 +10,7 @@ url: https://www.rosa3d.pl/en/filament-3d-refill-pla-cf-matt-stone-cold-gray-175
 primary_color:
   color_rgba: '#a2aaadff'
 tags:
-- contains_carbon_fiber
-- matte
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - matte
+  - abrasive
 properties: {}

--- a/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-stone-warm-gray.yaml
+++ b/data/materials/rosa3d-filaments/rosa3d-filaments-pla-cf-matt-stone-warm-gray.yaml
@@ -10,8 +10,7 @@ url: https://www.rosa3d.pl/en/filament-3d-refill-pla-cf-matt-stone-warm-gray-175
 primary_color:
   color_rgba: '#a8b39bff'
 tags:
-- contains_carbon_fiber
-- matte
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - matte
+  - abrasive
 properties: {}

--- a/data/materials/siddament/siddament-pla-carbon-fiber.yaml
+++ b/data/materials/siddament/siddament-pla-carbon-fiber.yaml
@@ -10,7 +10,6 @@ url: https://siddament.com.au/products/carbon-fiber-pla-1-75mm-1kg
 primary_color:
   color_rgba: '#0f0f0fff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/spectrum/spectrum-pla-carbon.yaml
+++ b/data/materials/spectrum/spectrum-pla-carbon.yaml
@@ -10,8 +10,7 @@ url: https://spectrumfilaments.com/en/filament/pla-carbon/
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties:
   density: 1.3

--- a/data/materials/spectrum/spectrum-the-filament-pla-cf-black.yaml
+++ b/data/materials/spectrum/spectrum-the-filament-pla-cf-black.yaml
@@ -10,8 +10,7 @@ url: https://spectrumfilaments.com/en/filament/the-filament-pla-cf/
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties:
   density: 1.22

--- a/data/materials/spectrum/spectrum-the-filament-pla-cf-blue.yaml
+++ b/data/materials/spectrum/spectrum-the-filament-pla-cf-blue.yaml
@@ -10,8 +10,7 @@ url: https://spectrumfilaments.com/en/filament/the-filament-pla-cf/
 primary_color:
   color_rgba: '#0353baff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties:
   density: 1.22

--- a/data/materials/spectrum/spectrum-the-filament-pla-cf-grey.yaml
+++ b/data/materials/spectrum/spectrum-the-filament-pla-cf-grey.yaml
@@ -10,8 +10,7 @@ url: https://spectrumfilaments.com/en/filament/the-filament-pla-cf/
 primary_color:
   color_rgba: '#aabccfff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties:
   density: 1.22

--- a/data/materials/spectrum/spectrum-the-filament-pla-cf-purple.yaml
+++ b/data/materials/spectrum/spectrum-the-filament-pla-cf-purple.yaml
@@ -10,8 +10,7 @@ url: https://spectrumfilaments.com/en/filament/the-filament-pla-cf/
 primary_color:
   color_rgba: '#7142a3ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties:
   density: 1.22

--- a/data/materials/spectrum/spectrum-the-filament-pla-cf-red.yaml
+++ b/data/materials/spectrum/spectrum-the-filament-pla-cf-red.yaml
@@ -10,8 +10,7 @@ url: https://spectrumfilaments.com/en/filament/the-filament-pla-cf/
 primary_color:
   color_rgba: '#ad312dff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties:
   density: 1.22

--- a/data/materials/spectrum/spectrum-the-filament-pla-cf-violet.yaml
+++ b/data/materials/spectrum/spectrum-the-filament-pla-cf-violet.yaml
@@ -10,8 +10,7 @@ url: https://spectrumfilaments.com/en/filament/the-filament-pla-cf/
 primary_color:
   color_rgba: '#c80181ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties:
   density: 1.22

--- a/data/materials/spectrum/spectrum-the-filament-pla-cf.yaml
+++ b/data/materials/spectrum/spectrum-the-filament-pla-cf.yaml
@@ -10,8 +10,7 @@ url: https://spectrumfilaments.com/en/filament/the-filament-pla-cf/
 primary_color:
   color_rgba: '#11784fff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties:
   density: 1.22

--- a/data/materials/sunlu/sunlu-carbon-fiber-pla-black.yaml
+++ b/data/materials/sunlu/sunlu-carbon-fiber-pla-black.yaml
@@ -9,11 +9,10 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- recycled
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - recycled
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/sunlu/sunlu-carbon-fiber-pla-black/1b48f34a2dda.jpg
-  type: unspecified
+  - url: https://files.openprinttag.org/sunlu/sunlu-carbon-fiber-pla-black/1b48f34a2dda.jpg
+    type: unspecified
 properties: {}

--- a/data/materials/tinmorry/tinmorry-carbon-fiber-pla-black.yaml
+++ b/data/materials/tinmorry/tinmorry-carbon-fiber-pla-black.yaml
@@ -10,7 +10,6 @@ url: https://tinmorry.net/en-eu/products/carbon-fiber-pla-filament-1-75mm-1kg-ti
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/tinmorry/tinmorry-carbon-fiber-pla-brickred.yaml
+++ b/data/materials/tinmorry/tinmorry-carbon-fiber-pla-brickred.yaml
@@ -10,7 +10,6 @@ url: https://tinmorry.net/en-eu/products/carbon-fiber-pla-filament-1-75mm-tinmor
 primary_color:
   color_rgba: '#9f563eff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/tinmorry/tinmorry-carbon-fiber-pla-carbon-blue.yaml
+++ b/data/materials/tinmorry/tinmorry-carbon-fiber-pla-carbon-blue.yaml
@@ -10,7 +10,6 @@ url: https://tinmorry.net/en-eu/products/carbon-fiber-pla-filament-1-75mm-tinmor
 primary_color:
   color_rgba: '#375680ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/tinmorry/tinmorry-carbon-fiber-pla-coolgrey.yaml
+++ b/data/materials/tinmorry/tinmorry-carbon-fiber-pla-coolgrey.yaml
@@ -10,7 +10,6 @@ url: https://tinmorry.net/en-eu/products/carbon-fiber-pla-filament-1-75mm-tinmor
 primary_color:
   color_rgba: '#5a696cff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/tinmorry/tinmorry-carbon-fiber-pla-earth-yellow.yaml
+++ b/data/materials/tinmorry/tinmorry-carbon-fiber-pla-earth-yellow.yaml
@@ -10,7 +10,6 @@ url: https://tinmorry.net/en-eu/products/carbon-fiber-pla-filament-1-75mm-tinmor
 primary_color:
   color_rgba: '#73755eff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/tinmorry/tinmorry-carbon-fiber-pla-greygreen.yaml
+++ b/data/materials/tinmorry/tinmorry-carbon-fiber-pla-greygreen.yaml
@@ -10,7 +10,6 @@ url: https://tinmorry.net/en-eu/products/carbon-fiber-pla-filament-1-75mm-tinmor
 primary_color:
   color_rgba: '#656d60ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/tinmorry/tinmorry-carbon-fiber-pla-lightbrown.yaml
+++ b/data/materials/tinmorry/tinmorry-carbon-fiber-pla-lightbrown.yaml
@@ -10,7 +10,6 @@ url: https://tinmorry.net/en-eu/products/carbon-fiber-pla-filament-1-75mm-tinmor
 primary_color:
   color_rgba: '#8c7547ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/tinmorry/tinmorry-carbon-fiber-pla-purple-grey.yaml
+++ b/data/materials/tinmorry/tinmorry-carbon-fiber-pla-purple-grey.yaml
@@ -10,7 +10,6 @@ url: https://tinmorry.net/en-eu/products/carbon-fiber-pla-filament-1-75mm-tinmor
 primary_color:
   color_rgba: '#4c5051ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/ziro-3d/ziro-3d-carbon-fiber-pla-black.yaml
+++ b/data/materials/ziro-3d/ziro-3d-carbon-fiber-pla-black.yaml
@@ -10,7 +10,6 @@ url: https://ziro3d.com/products/ziro-carbon-fiber-pla-filament-1-75mm-black
 primary_color:
   color_rgba: '#3c3c53ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/ziro-3d/ziro-3d-carbon-fiber-pla-military-green.yaml
+++ b/data/materials/ziro-3d/ziro-3d-carbon-fiber-pla-military-green.yaml
@@ -10,7 +10,6 @@ url: https://ziro3d.com/products/ziro-carbon-fiber-pla-filament-1-75mm-military-
 primary_color:
   color_rgba: '#6e9954ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/ziro-3d/ziro-3d-carbon-fiber-pla-navy-blue.yaml
+++ b/data/materials/ziro-3d/ziro-3d-carbon-fiber-pla-navy-blue.yaml
@@ -10,7 +10,6 @@ url: https://ziro3d.com/products/ziro-carbon-fiber-pla-filament-1-75mm-navy-blue
 primary_color:
   color_rgba: '#3a0a8cff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/ziro-3d/ziro-3d-carbon-fiber-pla-space-gray.yaml
+++ b/data/materials/ziro-3d/ziro-3d-carbon-fiber-pla-space-gray.yaml
@@ -10,7 +10,6 @@ url: https://ziro3d.com/products/ziro-carbon-fiber-pla-filament-1-75mm-space-gra
 primary_color:
   color_rgba: '#9fa0b4ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 properties: {}

--- a/data/materials/zyltech/zyltech-carbon-fiber-pla-composite.yaml
+++ b/data/materials/zyltech/zyltech-carbon-fiber-pla-composite.yaml
@@ -9,10 +9,9 @@ abbreviation: PLA
 primary_color:
   color_rgba: '#000000ff'
 tags:
-- contains_carbon_fiber
-- abrasive
-- industrially_compostable
+  - contains_carbon_fiber
+  - abrasive
 photos:
-- url: https://files.openprinttag.org/zyltech/zyltech-carbon-fiber-pla-composite/acca8a99cec2.png
-  type: unspecified
+  - url: https://files.openprinttag.org/zyltech/zyltech-carbon-fiber-pla-composite/acca8a99cec2.png
+    type: unspecified
 properties: {}


### PR DESCRIPTION
This bulk change removes the incorrectly applied 'industrially_compostable' tag from all 107 PLA materials that also carry 'contains_carbon_fiber' or 'contains_glass_fiber'.

Updated filaments from:
3dxtech, amolen, anycubic, arianeplast, atomic-filament, bambulab, creality, elegoo, esun, fiberthree, filamentree, flashforge, geeetech, hatchbox, kingroon, matter3d-inc, mexico-makers, nobufil, numakers, overture, polymaker, primacreator, print-with-smile, printedsolid, protopasta, qidi, rosa3d-filaments, siddament, spectrum, sunlu, tinmorry, ziro-3d, zyltech