### PR TITLE
Add Anycubic PLA Silk Dual/Tri-Color materials and packages

### DIFF
--- a/data/material-packages/anycubic/anycubic-pla-silk-dual-color-black-blue-1kg.yaml
+++ b/data/material-packages/anycubic/anycubic-pla-silk-dual-color-black-blue-1kg.yaml
@@ -1,0 +1,10 @@
+slug: anycubic-pla-silk-dual-color-black-blue-1kg
+class: FFF
+brand_specific_id: AHSC08-102
+url: https://store.anycubic.com/products/silk-pla-dual-tri-color-filament?variant=44440649138338
+material:
+  slug: anycubic-pla-silk-dual-color-black-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: anycubic-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/anycubic/anycubic-pla-silk-dual-color-black-gold-1kg.yaml
+++ b/data/material-packages/anycubic/anycubic-pla-silk-dual-color-black-gold-1kg.yaml
@@ -1,0 +1,10 @@
+slug: anycubic-pla-silk-dual-color-black-gold-1kg
+class: FFF
+brand_specific_id: AHSC07-102
+url: https://store.anycubic.com/products/silk-pla-dual-tri-color-filament?variant=44440649105570
+material:
+  slug: anycubic-pla-silk-dual-color-black-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: anycubic-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/anycubic/anycubic-pla-silk-dual-color-black-green-1kg.yaml
+++ b/data/material-packages/anycubic/anycubic-pla-silk-dual-color-black-green-1kg.yaml
@@ -1,0 +1,10 @@
+slug: anycubic-pla-silk-dual-color-black-green-1kg
+class: FFF
+brand_specific_id: AHSC09-102
+url: https://store.anycubic.com/products/silk-pla-dual-tri-color-filament?variant=44440649171106
+material:
+  slug: anycubic-pla-silk-dual-color-black-green
+nominal_netto_full_weight: 1000
+container:
+  slug: anycubic-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/anycubic/anycubic-pla-silk-dual-color-black-purple-1kg.yaml
+++ b/data/material-packages/anycubic/anycubic-pla-silk-dual-color-black-purple-1kg.yaml
@@ -1,0 +1,10 @@
+slug: anycubic-pla-silk-dual-color-black-purple-1kg
+class: FFF
+brand_specific_id: AHSC10-102
+url: https://store.anycubic.com/products/silk-pla-dual-tri-color-filament?variant=44440649072802
+material:
+  slug: anycubic-pla-silk-dual-color-black-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: anycubic-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/anycubic/anycubic-pla-silk-dual-color-black-red-1kg.yaml
+++ b/data/material-packages/anycubic/anycubic-pla-silk-dual-color-black-red-1kg.yaml
@@ -1,0 +1,10 @@
+slug: anycubic-pla-silk-dual-color-black-red-1kg
+class: FFF
+brand_specific_id: AHSC17-102
+url: https://store.anycubic.com/products/silk-pla-dual-tri-color-filament?variant=45643391860898
+material:
+  slug: anycubic-pla-silk-dual-color-black-red
+nominal_netto_full_weight: 1000
+container:
+  slug: anycubic-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/anycubic/anycubic-pla-silk-dual-color-blue-green-1kg.yaml
+++ b/data/material-packages/anycubic/anycubic-pla-silk-dual-color-blue-green-1kg.yaml
@@ -1,0 +1,10 @@
+slug: anycubic-pla-silk-dual-color-blue-green-1kg
+class: FFF
+brand_specific_id: AHSC16-102
+url: https://store.anycubic.com/products/silk-pla-dual-tri-color-filament?variant=45643391828130
+material:
+  slug: anycubic-pla-silk-dual-color-blue-green
+nominal_netto_full_weight: 1000
+container:
+  slug: anycubic-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/anycubic/anycubic-pla-silk-dual-color-pink-gold-1kg.yaml
+++ b/data/material-packages/anycubic/anycubic-pla-silk-dual-color-pink-gold-1kg.yaml
@@ -1,0 +1,10 @@
+slug: anycubic-pla-silk-dual-color-pink-gold-1kg
+class: FFF
+brand_specific_id: AHSC11-102
+url: https://store.anycubic.com/products/silk-pla-dual-tri-color-filament?variant=44440649203874
+material:
+  slug: anycubic-pla-silk-dual-color-pink-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: anycubic-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/anycubic/anycubic-pla-silk-dual-color-red-blue-1kg.yaml
+++ b/data/material-packages/anycubic/anycubic-pla-silk-dual-color-red-blue-1kg.yaml
@@ -1,0 +1,10 @@
+slug: anycubic-pla-silk-dual-color-red-blue-1kg
+class: FFF
+brand_specific_id: AHSC13-102
+url: https://store.anycubic.com/products/silk-pla-dual-tri-color-filament?variant=44440707891362
+material:
+  slug: anycubic-pla-silk-dual-color-red-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: anycubic-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/anycubic/anycubic-pla-silk-dual-color-red-gold-1kg.yaml
+++ b/data/material-packages/anycubic/anycubic-pla-silk-dual-color-red-gold-1kg.yaml
@@ -1,0 +1,10 @@
+slug: anycubic-pla-silk-dual-color-red-gold-1kg
+class: FFF
+brand_specific_id: AHSC12-102
+url: https://store.anycubic.com/products/silk-pla-dual-tri-color-filament?variant=44440649236642
+material:
+  slug: anycubic-pla-silk-dual-color-red-gold
+nominal_netto_full_weight: 1000
+container:
+  slug: anycubic-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/anycubic/anycubic-pla-silk-tri-color-blue-green-purple-1kg.yaml
+++ b/data/material-packages/anycubic/anycubic-pla-silk-tri-color-blue-green-purple-1kg.yaml
@@ -1,0 +1,10 @@
+slug: anycubic-pla-silk-tri-color-blue-green-purple-1kg
+class: FFF
+brand_specific_id: AHSC14-102
+url: https://store.anycubic.com/products/silk-pla-dual-tri-color-filament?variant=44440708087970
+material:
+  slug: anycubic-pla-silk-tri-color-blue-green-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: anycubic-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/anycubic/anycubic-pla-silk-tri-color-red-blue-yellow-1kg.yaml
+++ b/data/material-packages/anycubic/anycubic-pla-silk-tri-color-red-blue-yellow-1kg.yaml
@@ -1,0 +1,10 @@
+slug: anycubic-pla-silk-tri-color-red-blue-yellow-1kg
+class: FFF
+brand_specific_id: AHSC18-102
+url: https://store.anycubic.com/products/silk-pla-dual-tri-color-filament?variant=45643391893666
+material:
+  slug: anycubic-pla-silk-tri-color-red-blue-yellow
+nominal_netto_full_weight: 1000
+container:
+  slug: anycubic-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/anycubic/anycubic-pla-silk-tri-color-red-yellow-green-1kg.yaml
+++ b/data/material-packages/anycubic/anycubic-pla-silk-tri-color-red-yellow-green-1kg.yaml
@@ -1,0 +1,10 @@
+slug: anycubic-pla-silk-tri-color-red-yellow-green-1kg
+class: FFF
+brand_specific_id: AHSC15-102
+url: https://store.anycubic.com/products/silk-pla-dual-tri-color-filament?variant=44440708284578
+material:
+  slug: anycubic-pla-silk-tri-color-red-yellow-green
+nominal_netto_full_weight: 1000
+container:
+  slug: anycubic-plastic-spool-1kg
+filament_diameter: 1750

--- a/data/materials/anycubic/anycubic-pla-silk-dual-color-black-blue.yaml
+++ b/data/materials/anycubic/anycubic-pla-silk-dual-color-black-blue.yaml
@@ -1,0 +1,25 @@
+uuid: 0984380c-8f93-562f-a6da-189b9bc87811
+slug: anycubic-pla-silk-dual-color-black-blue
+brand:
+  slug: anycubic
+name: PLA Silk Dual Color Black Blue
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#212721ff'
+- color_rgba: '#003594ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0245/5519/2380/files/PLA_Silk_Dual-Tri_black_blue_1.jpg?v=1775030826
+  type: unspecified
+properties:
+  density: 1.22
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 55
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/anycubic/anycubic-pla-silk-dual-color-black-gold.yaml
+++ b/data/materials/anycubic/anycubic-pla-silk-dual-color-black-gold.yaml
@@ -1,0 +1,25 @@
+uuid: 2ee4c21e-af13-54cf-bb09-40a15eccefc1
+slug: anycubic-pla-silk-dual-color-black-gold
+brand:
+  slug: anycubic
+name: PLA Silk Dual Color Black Gold
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#212721ff'
+- color_rgba: '#c8b643ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0245/5519/2380/files/PLA_Silk_Dual-Tri_black_gold_1.jpg?v=1775030826
+  type: unspecified
+properties:
+  density: 1.22
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 55
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/anycubic/anycubic-pla-silk-dual-color-black-green.yaml
+++ b/data/materials/anycubic/anycubic-pla-silk-dual-color-black-green.yaml
@@ -1,0 +1,25 @@
+uuid: 88bf2390-5349-52d1-b820-d2f44510af33
+slug: anycubic-pla-silk-dual-color-black-green
+brand:
+  slug: anycubic
+name: PLA Silk Dual Color Black Green
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#212721ff'
+- color_rgba: '#006f44ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0245/5519/2380/files/PLA_Silk_Dual-Tri_black_green_1.jpg?v=1775030826
+  type: unspecified
+properties:
+  density: 1.22
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 55
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/anycubic/anycubic-pla-silk-dual-color-black-purple.yaml
+++ b/data/materials/anycubic/anycubic-pla-silk-dual-color-black-purple.yaml
@@ -1,0 +1,25 @@
+uuid: fa84ab5a-ab74-5784-9544-5723b303399d
+slug: anycubic-pla-silk-dual-color-black-purple
+brand:
+  slug: anycubic
+name: PLA Silk Dual Color Black Purple
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#212721ff'
+- color_rgba: '#7249c7ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0245/5519/2380/files/PLA_Silk_Dual-Tri_black_purple_1.jpg?v=1775030826
+  type: unspecified
+properties:
+  density: 1.22
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 55
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/anycubic/anycubic-pla-silk-dual-color-black-red.yaml
+++ b/data/materials/anycubic/anycubic-pla-silk-dual-color-black-red.yaml
@@ -1,0 +1,25 @@
+uuid: e13492d3-6bc1-5b6f-a31c-2f42bd5c64d6
+slug: anycubic-pla-silk-dual-color-black-red
+brand:
+  slug: anycubic
+name: PLA Silk Dual Color Black Red
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#212721ff'
+- color_rgba: '#d22630ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0245/5519/2380/files/PLA_Silk_Dual-Tri_black_red_1.jpg?v=1775030826
+  type: unspecified
+properties:
+  density: 1.22
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 55
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/anycubic/anycubic-pla-silk-dual-color-blue-green.yaml
+++ b/data/materials/anycubic/anycubic-pla-silk-dual-color-blue-green.yaml
@@ -1,0 +1,25 @@
+uuid: 9bfb38c4-0155-51cf-99d5-ad930e4c1265
+slug: anycubic-pla-silk-dual-color-blue-green
+brand:
+  slug: anycubic
+name: PLA Silk Dual Color Blue Green
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#003594ff'
+- color_rgba: '#006f44ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0245/5519/2380/files/PLA_Silk_Dual-Tri_blue_green_1.jpg?v=1775030826
+  type: unspecified
+properties:
+  density: 1.22
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 55
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/anycubic/anycubic-pla-silk-dual-color-pink-gold.yaml
+++ b/data/materials/anycubic/anycubic-pla-silk-dual-color-pink-gold.yaml
@@ -1,0 +1,25 @@
+uuid: 1e9fc17a-5854-5e0b-93a6-48256cda00fd
+slug: anycubic-pla-silk-dual-color-pink-gold
+brand:
+  slug: anycubic
+name: PLA Silk Dual Color Pink Gold
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#f67599ff'
+- color_rgba: '#f2a900ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0245/5519/2380/files/PLA_Silk_Dual-Tri_gold_pink_1.jpg?v=1775030826
+  type: unspecified
+properties:
+  density: 1.22
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 55
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/anycubic/anycubic-pla-silk-dual-color-red-blue.yaml
+++ b/data/materials/anycubic/anycubic-pla-silk-dual-color-red-blue.yaml
@@ -1,0 +1,22 @@
+uuid: 3d306f83-4a15-5f3d-9111-a45265aeb70a
+slug: anycubic-pla-silk-dual-color-red-blue
+brand:
+  slug: anycubic
+name: PLA Silk Dual Color Red Blue
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#e63888ff'
+- color_rgba: '#003594ff'
+tags:
+- silk
+- coextruded
+properties:
+  density: 1.22
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 55
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/anycubic/anycubic-pla-silk-dual-color-red-gold.yaml
+++ b/data/materials/anycubic/anycubic-pla-silk-dual-color-red-gold.yaml
@@ -1,0 +1,25 @@
+uuid: 10f16a8f-8449-5830-b002-9f87d2036663
+slug: anycubic-pla-silk-dual-color-red-gold
+brand:
+  slug: anycubic
+name: PLA Silk Dual Color Red Gold
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#d22630ff'
+- color_rgba: '#ffc600ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0245/5519/2380/files/PLA_Silk_Dual-Tri_red_gold_1.jpg?v=1775030826
+  type: unspecified
+properties:
+  density: 1.22
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 55
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/anycubic/anycubic-pla-silk-tri-color-blue-green-purple.yaml
+++ b/data/materials/anycubic/anycubic-pla-silk-tri-color-blue-green-purple.yaml
@@ -1,0 +1,26 @@
+uuid: bdba2d2f-0a25-5340-8d92-855e49d2b04b
+slug: anycubic-pla-silk-tri-color-blue-green-purple
+brand:
+  slug: anycubic
+name: PLA Silk Tri Color Blue Green Purple
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#003594ff'
+- color_rgba: '#006f44ff'
+- color_rgba: '#452b6fff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0245/5519/2380/files/PLA_Silk_Dual-Tri_blue_green_purple_1.jpg?v=1775030826
+  type: unspecified
+properties:
+  density: 1.22
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 55
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/anycubic/anycubic-pla-silk-tri-color-red-blue-yellow.yaml
+++ b/data/materials/anycubic/anycubic-pla-silk-tri-color-red-blue-yellow.yaml
@@ -1,0 +1,26 @@
+uuid: d8265822-db6f-5f64-8417-3696b623c5e8
+slug: anycubic-pla-silk-tri-color-red-blue-yellow
+brand:
+  slug: anycubic
+name: PLA Silk Tri Color Red Blue Yellow
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#c8102eff'
+- color_rgba: '#003594ff'
+- color_rgba: '#f3e500ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0245/5519/2380/files/PLA_Silk_Dual-Tri_red_yellow_blue_1.jpg?v=1775030826
+  type: unspecified
+properties:
+  density: 1.22
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 55
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480

--- a/data/materials/anycubic/anycubic-pla-silk-tri-color-red-yellow-green.yaml
+++ b/data/materials/anycubic/anycubic-pla-silk-tri-color-red-yellow-green.yaml
@@ -1,0 +1,26 @@
+uuid: 2be3ed50-cd74-506b-bb36-1ebb28779b7f
+slug: anycubic-pla-silk-tri-color-red-yellow-green
+brand:
+  slug: anycubic
+name: PLA Silk Tri Color Red Yellow Green
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#d22630ff'
+- color_rgba: '#f3d03eff'
+- color_rgba: '#006f44ff'
+tags:
+- silk
+- coextruded
+photos:
+- url: https://cdn.shopify.com/s/files/1/0245/5519/2380/files/PLA_Silk_Dual-Tri_red_yellow_green_1.jpg?v=1775030826
+  type: unspecified
+properties:
+  density: 1.22
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 55
+  max_bed_temperature: 65
+  drying_temperature: 55
+  drying_time: 480


### PR DESCRIPTION
Adds Anycubic's full **PLA Silk Dual/Tri-Color** coextrusion line — 12 colors, none of which were in the database. Data is from Anycubic's official
  PLA Silk technical data sheet (V3.0) and the store.anycubic.com product listing.

  ### Materials (12)
  Coextruded silk PLA, using `secondary_colors`:
  - **Dual (9):** Black Blue, Black Purple, Black Red, Black Green, Black Gold, Red Gold, Pink Gold, Red Blue, Blue Green
  - **Tri (3):** Blue Green Purple, Red Yellow Green, Red Blue Yellow

  Tags `silk` + `coextruded`. Properties from the Anycubic PLA Silk TDS: density 1.22, nozzle 210–240 °C, bed 55–65 °C, drying 55 °C / 8 h. (Melt
  index, tensile/impact, Tg/HDT/Vicat, etc. have no schema field and were omitted.)

  ### Packages (12)
  1 kg / 1.75 mm, each linking its material to the existing `anycubic-plastic-spool-1kg` container, with the product URL and the per-color SKU (`brand_specific_id`).

  ### Notes
  - **No GTIN:** the store lists the same placeholder barcode on every color, so packages are shipped GTIN-less rather than storing an incorrect/duplicate one.
  - Photos on materials only; URLs on packages only.
  - Red Blue has no product image on the store, so its material ships without a photo (addable later).