### PR TITLE
Add STLFLIX brand, PLA materials, spool container, and packages

### DIFF
--- a/data/brands/stlflix.yaml
+++ b/data/brands/stlflix.yaml
@@ -1,0 +1,5 @@
+uuid: 62ef6d1e-7192-5c98-80e2-2a976909b8cf
+slug: stlflix
+name: STLFLIX
+countries_of_origin:
+- BR

--- a/data/material-containers/stlflix-spool-1kg.yaml
+++ b/data/material-containers/stlflix-spool-1kg.yaml
@@ -1,0 +1,10 @@
+uuid: a2575589-edf4-46d4-b124-954a3df9b3fc
+slug: stlflix-spool-1kg
+name: STLFLIX Spool 1kg
+class: FFF
+brand:
+  slug: stlflix
+hole_diameter: 54
+outer_diameter: 195
+width: 59
+empty_weight: 240

--- a/data/material-packages/stlflix/stlflix-pla-beige-1kg.yaml
+++ b/data/material-packages/stlflix/stlflix-pla-beige-1kg.yaml
@@ -1,0 +1,8 @@
+slug: stlflix-pla-beige-1kg
+class: FFF
+material:
+  slug: stlflix-pla-beige
+nominal_netto_full_weight: 1000
+container:
+  slug: stlflix-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/stlflix/stlflix-pla-light-blue-1kg.yaml
+++ b/data/material-packages/stlflix/stlflix-pla-light-blue-1kg.yaml
@@ -1,0 +1,8 @@
+slug: stlflix-pla-light-blue-1kg
+class: FFF
+material:
+  slug: stlflix-pla-light-blue
+nominal_netto_full_weight: 1000
+container:
+  slug: stlflix-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/stlflix/stlflix-pla-light-pink-1kg.yaml
+++ b/data/material-packages/stlflix/stlflix-pla-light-pink-1kg.yaml
@@ -1,0 +1,9 @@
+slug: stlflix-pla-light-pink-1kg
+class: FFF
+url: https://stlflix.com.br/produto/pla_rosaclaro/
+material:
+  slug: stlflix-pla-light-pink
+nominal_netto_full_weight: 1000
+container:
+  slug: stlflix-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/stlflix/stlflix-pla-purple-1kg.yaml
+++ b/data/material-packages/stlflix/stlflix-pla-purple-1kg.yaml
@@ -1,0 +1,9 @@
+slug: stlflix-pla-purple-1kg
+class: FFF
+url: https://stlflix.com.br/produto/pla_roxo/
+material:
+  slug: stlflix-pla-purple
+nominal_netto_full_weight: 1000
+container:
+  slug: stlflix-spool-1kg
+filament_diameter: 1750

--- a/data/material-packages/stlflix/stlflix-pla-silk-purple-blue-1kg.yaml
+++ b/data/material-packages/stlflix/stlflix-pla-silk-purple-blue-1kg.yaml
@@ -1,0 +1,6 @@
+slug: stlflix-pla-silk-purple-blue-1kg
+class: FFF
+material:
+  slug: stlflix-pla-silk-purple-blue
+nominal_netto_full_weight: 1000
+filament_diameter: 1750

--- a/data/materials/stlflix/stlflix-pla-beige.yaml
+++ b/data/materials/stlflix/stlflix-pla-beige.yaml
@@ -1,0 +1,16 @@
+uuid: 90633bc6-40c6-5367-ab3e-bb487a115887
+slug: stlflix-pla-beige
+brand:
+  slug: stlflix
+name: PLA Beige
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#f2d4c0ff'
+properties:
+  density: 1.24
+  min_print_temperature: 195
+  max_print_temperature: 230
+  min_bed_temperature: 60
+  max_bed_temperature: 60

--- a/data/materials/stlflix/stlflix-pla-light-blue.yaml
+++ b/data/materials/stlflix/stlflix-pla-light-blue.yaml
@@ -1,0 +1,16 @@
+uuid: e10dc499-0a2a-5d50-b7bb-69a935cf19b0
+slug: stlflix-pla-light-blue
+brand:
+  slug: stlflix
+name: PLA Light Blue
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#00c7fcff'
+properties:
+  density: 1.24
+  min_print_temperature: 195
+  max_print_temperature: 230
+  min_bed_temperature: 60
+  max_bed_temperature: 60

--- a/data/materials/stlflix/stlflix-pla-light-pink.yaml
+++ b/data/materials/stlflix/stlflix-pla-light-pink.yaml
@@ -1,0 +1,19 @@
+uuid: fbe01474-494a-55af-9279-2bd4f3a1fcea
+slug: stlflix-pla-light-pink
+brand:
+  slug: stlflix
+name: PLA Light Pink
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#f7bbd5ff'
+photos:
+- url: https://stlflix.com.br/wp-content/uploads/2024/10/RosaClaro3.png
+  type: unspecified
+properties:
+  density: 1.24
+  min_print_temperature: 195
+  max_print_temperature: 230
+  min_bed_temperature: 60
+  max_bed_temperature: 60

--- a/data/materials/stlflix/stlflix-pla-purple.yaml
+++ b/data/materials/stlflix/stlflix-pla-purple.yaml
@@ -1,0 +1,19 @@
+uuid: 5ca358a3-d867-546e-9767-acbee93d20b5
+slug: stlflix-pla-purple
+brand:
+  slug: stlflix
+name: PLA Purple
+class: FFF
+type: PLA
+abbreviation: PLA
+primary_color:
+  color_rgba: '#862b7fff'
+photos:
+- url: https://stlflix.com.br/wp-content/uploads/2024/10/Roxo2.png
+  type: unspecified
+properties:
+  density: 1.24
+  min_print_temperature: 195
+  max_print_temperature: 230
+  min_bed_temperature: 60
+  max_bed_temperature: 60

--- a/data/materials/stlflix/stlflix-pla-silk-purple-blue.yaml
+++ b/data/materials/stlflix/stlflix-pla-silk-purple-blue.yaml
@@ -1,0 +1,19 @@
+uuid: c0a714c8-40c9-5087-94c5-2a1f6258b894
+slug: stlflix-pla-silk-purple-blue
+brand:
+  slug: stlflix
+name: PLA Silk Purple Blue
+class: FFF
+type: PLA
+abbreviation: PLA
+secondary_colors:
+- color_rgba: '#5e01bcff'
+- color_rgba: '#030ad8ff'
+tags:
+- silk
+- coextruded
+properties:
+  min_print_temperature: 195
+  max_print_temperature: 230
+  min_bed_temperature: 60
+  max_bed_temperature: 60


### PR DESCRIPTION
Adds the Brazilian brand **STLFLIX** (stlflix.com.br) — new brand, 5 PLA materials, a spool container, and packages. Data is from STLFLIX's product pages and physical spool measurements/labels.
  
  ### Brand
  `stlflix` — STLFLIX, Brazil (BR).

  ### Materials (5)
  - **4 Basic PLA** — Purple, Beige, Light Blue, Light Pink. Colors from official swatches; properties from the product pages: density 1.24 g/cm³, nozzle 195–230 °C, bed 60 °C.
  - **1 PLA Silk (dual-color, coextruded)** — Purple Blue (`secondary_colors`). A discontinued color; nozzle 195–230 °C, bed 60 °C.

  Photos (on materials) added where a manufacturer image was available (Purple, Light Pink).

  ### Container
  `stlflix-spool-1kg` — measured plastic spool: empty 240 g, hole 54 mm, outer 195 mm, width 59 mm.

  ### Packages (5)
  1 kg / 1.75 mm. The 4 Basic PLA link to the spool container; **Purple and Light Pink carry product URLs** (still sold). Beige, Light Blue, and the silk are **discontinued** (not in the current catalog), so they ship URL-less. The silk is **container-less** — it uses a different spool with no data available yet.

  ### Notes
  - No GTINs/SKUs (store exposes none).
  - Photos on materials only; URLs on packages only.
  - Deferred (discontinued, no current data): Beige/Light Blue URLs, the silk's own spool + URL