### PR TITLE
Update ABS filaments (Polymaker)

### DIFF
--- a/data/material-packages/polymaker/polymaker-polylite-galaxy-abs-black-1kg.yaml
+++ b/data/material-packages/polymaker/polymaker-polylite-galaxy-abs-black-1kg.yaml
@@ -1,0 +1,9 @@
+uuid: 72822aee-932b-5295-a6d0-20d4a29d6ae6
+slug: polymaker-polylite-galaxy-abs-black-1kg
+class: FFF
+material:
+  slug: polymaker-polylite-galaxy-abs-black
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+gtin: 6938936713746
+url: https://us.polymaker.com/products/polylite-galaxy-abs

--- a/data/material-packages/polymaker/polymaker-polylite-galaxy-abs-dark-grey-1kg.yaml
+++ b/data/material-packages/polymaker/polymaker-polylite-galaxy-abs-dark-grey-1kg.yaml
@@ -1,0 +1,9 @@
+uuid: 7bbfdd81-2537-57a4-a28d-5067d52ae8c6
+slug: polymaker-polylite-galaxy-abs-dark-grey-1kg
+class: FFF
+material:
+  slug: polymaker-polylite-galaxy-abs-dark-grey
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+gtin: 6938936707950
+url: https://us.polymaker.com/products/polylite-galaxy-abs?variant=41212532129849

--- a/data/material-packages/polymaker/polymaker-polylite-galaxy-abs-orange-1kg.yaml
+++ b/data/material-packages/polymaker/polymaker-polylite-galaxy-abs-orange-1kg.yaml
@@ -1,0 +1,9 @@
+uuid: 71e56c85-4ef9-55d5-815e-d30b9843cd67
+slug: polymaker-polylite-galaxy-abs-orange-1kg
+class: FFF
+material:
+  slug: polymaker-polylite-galaxy-abs-orange
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+gtin: 6938936707936
+url: https://us.polymaker.com/products/polylite-galaxy-abs?variant=41212532228153

--- a/data/material-packages/polymaker/polymaker-polylite-galaxy-abs-purple-1kg.yaml
+++ b/data/material-packages/polymaker/polymaker-polylite-galaxy-abs-purple-1kg.yaml
@@ -1,0 +1,9 @@
+uuid: dffb8118-d8da-5ebc-91d2-953162a32428
+slug: polymaker-polylite-galaxy-abs-purple-1kg
+class: FFF
+material:
+  slug: polymaker-polylite-galaxy-abs-purple
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+gtin: 6938936707943
+url: https://us.polymaker.com/products/polylite-galaxy-abs?variant=41212532162617

--- a/data/material-packages/polymaker/polymaker-polylite-galaxy-abs-teal-1kg.yaml
+++ b/data/material-packages/polymaker/polymaker-polylite-galaxy-abs-teal-1kg.yaml
@@ -1,0 +1,9 @@
+uuid: d864bacb-6d53-5390-a077-fccd1a22a58d
+slug: polymaker-polylite-galaxy-abs-teal-1kg
+class: FFF
+material:
+  slug: polymaker-polylite-galaxy-abs-teal
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+gtin: 6938936707967
+url: https://us.polymaker.com/products/polylite-galaxy-abs?variant=41212532195385

--- a/data/material-packages/polymaker/polymaker-polylite-metallic-abs-blue-1kg.yaml
+++ b/data/material-packages/polymaker/polymaker-polylite-metallic-abs-blue-1kg.yaml
@@ -1,0 +1,9 @@
+uuid: c50cbbb6-e168-5859-884f-629ecf258ce6
+slug: polymaker-polylite-metallic-abs-blue-1kg
+class: FFF
+material:
+  slug: polymaker-polylite-metallic-abs-blue
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+gtin: 6938936691736
+url: https://us.polymaker.com/products/polylite-abs-metallic

--- a/data/material-packages/polymaker/polymaker-polylite-metallic-abs-green-1kg.yaml
+++ b/data/material-packages/polymaker/polymaker-polylite-metallic-abs-green-1kg.yaml
@@ -1,0 +1,9 @@
+uuid: 4be0f1e0-9d83-5a21-9a1d-5b1ecde110bd
+slug: polymaker-polylite-metallic-abs-green-1kg
+class: FFF
+material:
+  slug: polymaker-polylite-metallic-abs-green
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+gtin: 6938936696945
+url: https://us.polymaker.com/products/polylite-abs-metallic?variant=42510087716921

--- a/data/material-packages/polymaker/polymaker-polylite-neon-abs-green-1kg.yaml
+++ b/data/material-packages/polymaker/polymaker-polylite-neon-abs-green-1kg.yaml
@@ -1,0 +1,9 @@
+uuid: 4999c220-cc78-55f6-bbb6-80cd96de6cd9
+slug: polymaker-polylite-neon-abs-green-1kg
+class: FFF
+material:
+  slug: polymaker-polylite-neon-abs-green
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+gtin: 6938936713562
+url: https://us.polymaker.com/products/polylite-neon-abs

--- a/data/material-packages/polymaker/polymaker-polylite-neon-abs-magenta-1kg.yaml
+++ b/data/material-packages/polymaker/polymaker-polylite-neon-abs-magenta-1kg.yaml
@@ -1,0 +1,9 @@
+uuid: c0900cb4-b89c-56fc-8223-01d5f0a94861
+slug: polymaker-polylite-neon-abs-magenta-1kg
+class: FFF
+material:
+  slug: polymaker-polylite-neon-abs-magenta
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+gtin: 6938936713531
+url: https://us.polymaker.com/products/polylite-neon-abs?variant=41404997304377

--- a/data/material-packages/polymaker/polymaker-polylite-neon-abs-orange-1kg.yaml
+++ b/data/material-packages/polymaker/polymaker-polylite-neon-abs-orange-1kg.yaml
@@ -1,0 +1,9 @@
+uuid: bdaf54d5-f99d-5e6c-9916-3ce6c1cabf89
+slug: polymaker-polylite-neon-abs-orange-1kg
+class: FFF
+material:
+  slug: polymaker-polylite-neon-abs-orange
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+gtin: 6938936713548
+url: https://us.polymaker.com/products/polylite-neon-abs?variant=41404997271609

--- a/data/material-packages/polymaker/polymaker-polylite-neon-abs-yellow-1kg.yaml
+++ b/data/material-packages/polymaker/polymaker-polylite-neon-abs-yellow-1kg.yaml
@@ -1,0 +1,9 @@
+uuid: 3d3255bf-6c6a-5956-860f-d264dc8166a8
+slug: polymaker-polylite-neon-abs-yellow-1kg
+class: FFF
+material:
+  slug: polymaker-polylite-neon-abs-yellow
+nominal_netto_full_weight: 1000
+filament_diameter: 1750
+gtin: 6938936713555
+url: https://us.polymaker.com/products/polylite-neon-abs?variant=41404997238841

--- a/data/materials/polymaker/polymaker-polylite-abs-blue.yaml
+++ b/data/materials/polymaker/polymaker-polylite-abs-blue.yaml
@@ -7,7 +7,7 @@ class: FFF
 type: ABS
 abbreviation: ABS
 primary_color:
-  color_rgba: '#003276ff'
+  color_rgba: '#003576ff'
 tags:
   - filtration_recommended
 photos:

--- a/data/materials/polymaker/polymaker-polylite-abs-natural.yaml
+++ b/data/materials/polymaker/polymaker-polylite-abs-natural.yaml
@@ -7,7 +7,7 @@ class: FFF
 type: ABS
 abbreviation: ABS
 primary_color:
-  color_rgba: '#f7f5edff'
+  color_rgba: '#dfd3c3ff'
 tags:
   - without_pigments
   - filtration_recommended

--- a/data/materials/polymaker/polymaker-polylite-galaxy-abs-black.yaml
+++ b/data/materials/polymaker/polymaker-polylite-galaxy-abs-black.yaml
@@ -7,11 +7,18 @@ class: FFF
 type: ABS
 abbreviation: ABS
 primary_color:
-  color_rgba: '#000000ff'
+  color_rgba: '#17161aff'
 tags:
-- glitter
-- filtration_recommended
+  - glitter
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/polymaker/polymaker-polylite-galaxy-abs-black/45290feca03a.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/polymaker/polymaker-polylite-galaxy-abs-black/45290feca03a.png
+    type: unspecified
+properties:
+  density: 1.04
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 90
+  max_bed_temperature: 100
+  drying_temperature: 70
+  drying_time: 360

--- a/data/materials/polymaker/polymaker-polylite-galaxy-abs-dark-grey.yaml
+++ b/data/materials/polymaker/polymaker-polylite-galaxy-abs-dark-grey.yaml
@@ -7,11 +7,18 @@ class: FFF
 type: ABS
 abbreviation: ABS
 primary_color:
-  color_rgba: '#6a6c6eff'
+  color_rgba: '#474648ff'
 tags:
-- glitter
-- filtration_recommended
+  - glitter
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/polymaker/polymaker-polylite-galaxy-abs-dark-grey/7e55611549d0.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/polymaker/polymaker-polylite-galaxy-abs-dark-grey/7e55611549d0.png
+    type: unspecified
+properties:
+  density: 1.04
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 90
+  max_bed_temperature: 100
+  drying_temperature: 70
+  drying_time: 360

--- a/data/materials/polymaker/polymaker-polylite-galaxy-abs-orange.yaml
+++ b/data/materials/polymaker/polymaker-polylite-galaxy-abs-orange.yaml
@@ -7,11 +7,18 @@ class: FFF
 type: ABS
 abbreviation: ABS
 primary_color:
-  color_rgba: '#f97429ff'
+  color_rgba: '#f57517ff'
 tags:
-- glitter
-- filtration_recommended
+  - glitter
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/polymaker/polymaker-polylite-galaxy-abs-orange/8b624d5c82a5.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/polymaker/polymaker-polylite-galaxy-abs-orange/8b624d5c82a5.png
+    type: unspecified
+properties:
+  density: 1.04
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 90
+  max_bed_temperature: 100
+  drying_temperature: 70
+  drying_time: 360

--- a/data/materials/polymaker/polymaker-polylite-galaxy-abs-purple.yaml
+++ b/data/materials/polymaker/polymaker-polylite-galaxy-abs-purple.yaml
@@ -7,11 +7,18 @@ class: FFF
 type: ABS
 abbreviation: ABS
 primary_color:
-  color_rgba: '#6c5bb1ff'
+  color_rgba: '#6545a5ff'
 tags:
-- glitter
-- filtration_recommended
+  - glitter
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/polymaker/polymaker-polylite-galaxy-abs-purple/f7cd40384101.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/polymaker/polymaker-polylite-galaxy-abs-purple/f7cd40384101.png
+    type: unspecified
+properties:
+  density: 1.04
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 90
+  max_bed_temperature: 100
+  drying_temperature: 70
+  drying_time: 360

--- a/data/materials/polymaker/polymaker-polylite-galaxy-abs-teal.yaml
+++ b/data/materials/polymaker/polymaker-polylite-galaxy-abs-teal.yaml
@@ -7,11 +7,18 @@ class: FFF
 type: ABS
 abbreviation: ABS
 primary_color:
-  color_rgba: '#00b4bcff'
+  color_rgba: '#2dccd3ff'
 tags:
-- glitter
-- filtration_recommended
+  - glitter
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/polymaker/polymaker-polylite-galaxy-abs-teal/53daea9f1232.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/polymaker/polymaker-polylite-galaxy-abs-teal/53daea9f1232.png
+    type: unspecified
+properties:
+  density: 1.04
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 90
+  max_bed_temperature: 100
+  drying_temperature: 70
+  drying_time: 360

--- a/data/materials/polymaker/polymaker-polylite-metallic-abs-blue.yaml
+++ b/data/materials/polymaker/polymaker-polylite-metallic-abs-blue.yaml
@@ -7,11 +7,18 @@ class: FFF
 type: ABS
 abbreviation: ABS
 primary_color:
-  color_rgba: '#033877ff'
+  color_rgba: '#0d2441ff'
 tags:
-- silk
-- filtration_recommended
+  - imitates_metal
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/polymaker/polymaker-polylite-metallic-abs-blue/c48918639105.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/polymaker/polymaker-polylite-metallic-abs-blue/c48918639105.png
+    type: unspecified
+properties:
+  density: 1.04
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 90
+  max_bed_temperature: 100
+  drying_temperature: 70
+  drying_time: 360

--- a/data/materials/polymaker/polymaker-polylite-metallic-abs-green.yaml
+++ b/data/materials/polymaker/polymaker-polylite-metallic-abs-green.yaml
@@ -7,11 +7,18 @@ class: FFF
 type: ABS
 abbreviation: ABS
 primary_color:
-  color_rgba: '#2a422dff'
+  color_rgba: '#3d441eff'
 tags:
-- silk
-- filtration_recommended
+  - imitates_metal
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/polymaker/polymaker-polylite-metallic-abs-green/5885debcf350.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/polymaker/polymaker-polylite-metallic-abs-green/5885debcf350.png
+    type: unspecified
+properties:
+  density: 1.04
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 90
+  max_bed_temperature: 100
+  drying_temperature: 70
+  drying_time: 360

--- a/data/materials/polymaker/polymaker-polylite-neon-abs-green.yaml
+++ b/data/materials/polymaker/polymaker-polylite-neon-abs-green.yaml
@@ -6,9 +6,6 @@ name: PolyLite™ Neon ABS Green
 class: FFF
 type: ABS
 abbreviation: ABS
-secondary_colors:
-  - color_rgba: '#7cef83ff'
-  - color_rgba: '#6feedbff'
 tags:
   - neon
   - filtration_recommended

--- a/data/materials/polymaker/polymaker-polylite-neon-abs-green.yaml
+++ b/data/materials/polymaker/polymaker-polylite-neon-abs-green.yaml
@@ -7,13 +7,21 @@ class: FFF
 type: ABS
 abbreviation: ABS
 secondary_colors:
-- color_rgba: '#7cef83ff'
-- color_rgba: '#6feedbff'
+  - color_rgba: '#7cef83ff'
+  - color_rgba: '#6feedbff'
 tags:
-- illuminescent_color_change
-- filtration_recommended
-- neon
+  - neon
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/polymaker/polymaker-polylite-neon-abs-green/60f5650c3ae8.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/polymaker/polymaker-polylite-neon-abs-green/60f5650c3ae8.png
+    type: unspecified
+properties:
+  density: 1.04
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 90
+  max_bed_temperature: 100
+  drying_temperature: 70
+  drying_time: 360
+primary_color:
+  color_rgba: '#77f0a2ff'

--- a/data/materials/polymaker/polymaker-polylite-neon-abs-magenta.yaml
+++ b/data/materials/polymaker/polymaker-polylite-neon-abs-magenta.yaml
@@ -6,9 +6,6 @@ name: PolyLite™ Neon ABS Magenta
 class: FFF
 type: ABS
 abbreviation: ABS
-secondary_colors:
-  - color_rgba: '#f300eaff'
-  - color_rgba: '#ed1536ff'
 tags:
   - neon
   - filtration_recommended

--- a/data/materials/polymaker/polymaker-polylite-neon-abs-magenta.yaml
+++ b/data/materials/polymaker/polymaker-polylite-neon-abs-magenta.yaml
@@ -7,13 +7,21 @@ class: FFF
 type: ABS
 abbreviation: ABS
 secondary_colors:
-- color_rgba: '#f300eaff'
-- color_rgba: '#ed1536ff'
+  - color_rgba: '#f300eaff'
+  - color_rgba: '#ed1536ff'
 tags:
-- illuminescent_color_change
-- filtration_recommended
-- neon
+  - neon
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/polymaker/polymaker-polylite-neon-abs-magenta/1398a72a5d1c.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/polymaker/polymaker-polylite-neon-abs-magenta/1398a72a5d1c.png
+    type: unspecified
+properties:
+  density: 1.04
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 90
+  max_bed_temperature: 100
+  drying_temperature: 70
+  drying_time: 360
+primary_color:
+  color_rgba: '#f6162eff'

--- a/data/materials/polymaker/polymaker-polylite-neon-abs-orange.yaml
+++ b/data/materials/polymaker/polymaker-polylite-neon-abs-orange.yaml
@@ -6,9 +6,6 @@ name: PolyLite™ Neon ABS Orange
 class: FFF
 type: ABS
 abbreviation: ABS
-secondary_colors:
-  - color_rgba: '#e20010ff'
-  - color_rgba: '#f97429ff'
 tags:
   - neon
   - filtration_recommended

--- a/data/materials/polymaker/polymaker-polylite-neon-abs-orange.yaml
+++ b/data/materials/polymaker/polymaker-polylite-neon-abs-orange.yaml
@@ -7,13 +7,21 @@ class: FFF
 type: ABS
 abbreviation: ABS
 secondary_colors:
-- color_rgba: '#e20010ff'
-- color_rgba: '#f97429ff'
+  - color_rgba: '#e20010ff'
+  - color_rgba: '#f97429ff'
 tags:
-- illuminescent_color_change
-- filtration_recommended
-- neon
+  - neon
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/polymaker/polymaker-polylite-neon-abs-orange/3d070134dbd3.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/polymaker/polymaker-polylite-neon-abs-orange/3d070134dbd3.png
+    type: unspecified
+properties:
+  density: 1.04
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 90
+  max_bed_temperature: 100
+  drying_temperature: 70
+  drying_time: 360
+primary_color:
+  color_rgba: '#fe602bff'

--- a/data/materials/polymaker/polymaker-polylite-neon-abs-yellow.yaml
+++ b/data/materials/polymaker/polymaker-polylite-neon-abs-yellow.yaml
@@ -6,8 +6,6 @@ name: PolyLite™ Neon ABS Yellow
 class: FFF
 type: ABS
 abbreviation: ABS
-secondary_colors:
-  - color_rgba: '#fbe200ff'
 tags:
   - neon
   - filtration_recommended

--- a/data/materials/polymaker/polymaker-polylite-neon-abs-yellow.yaml
+++ b/data/materials/polymaker/polymaker-polylite-neon-abs-yellow.yaml
@@ -7,11 +7,20 @@ class: FFF
 type: ABS
 abbreviation: ABS
 secondary_colors:
-- color_rgba: '#fbe200ff'
+  - color_rgba: '#fbe200ff'
 tags:
-- filtration_recommended
-- neon
+  - neon
+  - filtration_recommended
 photos:
-- url: https://files.openprinttag.org/polymaker/polymaker-polylite-neon-abs-yellow/ee3d59570674.png
-  type: unspecified
-properties: {}
+  - url: https://files.openprinttag.org/polymaker/polymaker-polylite-neon-abs-yellow/ee3d59570674.png
+    type: unspecified
+properties:
+  density: 1.04
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 90
+  max_bed_temperature: 100
+  drying_temperature: 70
+  drying_time: 360
+primary_color:
+  color_rgba: '#ffc001ff'


### PR DESCRIPTION
Updated:
- PolyLite™ Neon ABS (https://shop.polymaker.com/en-eu/products/polylite-neon-abs?variant=41404997206073) fixed hex color, added missing properties and packages with GTIN
-  PolyLite™ Galaxy ABS(https://shop.polymaker.com/en-eu/products/polylite-galaxy-abs?variant=41590523592761) - fixed hex color, added missing properties and packages with GTIN
- PolyLite™ Metallic ABS (https://shop.polymaker.com/en-eu/products/polylite-abs-metallic?variant=42510087684153) fixed hex colors and added missing properties and packages with GTIN, fixed tags.
- polymaker-polylite-abs-natural : fixed hex color
- polymaker-polylite-abs-blue: fixed hex color