### PR TITLE
Add Overture filament print settings

### DIFF
--- a/data/materials/overture/overture-abs-black.yaml
+++ b/data/materials/overture/overture-abs-black.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-abs-black/494e12523016.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-abs-blue.yaml
+++ b/data/materials/overture/overture-abs-blue.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-abs-blue/2f4e5829736d.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-abs-dark-red.yaml
+++ b/data/materials/overture/overture-abs-dark-red.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-abs-dark-red/e2d64680ee4f.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-abs-diamond-gray.yaml
+++ b/data/materials/overture/overture-abs-diamond-gray.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-abs-diamond-gray/6feace90c5b3.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-abs-diamond-orange.yaml
+++ b/data/materials/overture/overture-abs-diamond-orange.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-abs-diamond-orange/299d7e26f885.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-abs-diamond-purple.yaml
+++ b/data/materials/overture/overture-abs-diamond-purple.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-abs-diamond-purple/866cee42cce6.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-abs-glow-green.yaml
+++ b/data/materials/overture/overture-abs-glow-green.yaml
@@ -18,4 +18,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-abs-glow-green/ae1a7176abb5.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-abs-gray.yaml
+++ b/data/materials/overture/overture-abs-gray.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-abs-gray/97fe714329ae.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-abs-green.yaml
+++ b/data/materials/overture/overture-abs-green.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-abs-green/76c71cc55683.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-abs-natural.yaml
+++ b/data/materials/overture/overture-abs-natural.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-abs-natural/8d5a1f452042.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-abs-purple.yaml
+++ b/data/materials/overture/overture-abs-purple.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-abs-purple/d90062d3a2f8.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-abs-slate-gray.yaml
+++ b/data/materials/overture/overture-abs-slate-gray.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-abs-slate-gray/69c171a429a2.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-abs-white.yaml
+++ b/data/materials/overture/overture-abs-white.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-abs-white/c4c8c0ae6691.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-abs-yellow.yaml
+++ b/data/materials/overture/overture-abs-yellow.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-abs-yellow/27b3a5fcf7a9.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 265
+  min_bed_temperature: 80
+  max_bed_temperature: 100
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-asa-black.yaml
+++ b/data/materials/overture/overture-asa-black.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-asa-black/473ef45e16ff.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 70
+  max_bed_temperature: 95
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-asa-blue.yaml
+++ b/data/materials/overture/overture-asa-blue.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-asa-blue/75fee8f15fac.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 70
+  max_bed_temperature: 95
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-asa-brown.yaml
+++ b/data/materials/overture/overture-asa-brown.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-asa-brown/4be823028c3f.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 70
+  max_bed_temperature: 95
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-asa-diamond-blue.yaml
+++ b/data/materials/overture/overture-asa-diamond-blue.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-asa-diamond-blue/2261e584c243.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 70
+  max_bed_temperature: 95
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-asa-diamond-green.yaml
+++ b/data/materials/overture/overture-asa-diamond-green.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-asa-diamond-green/8538e8ec3a08.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 70
+  max_bed_temperature: 95
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-asa-diamond-red.yaml
+++ b/data/materials/overture/overture-asa-diamond-red.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-asa-diamond-red/cb971fe6f813.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 70
+  max_bed_temperature: 95
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-asa-gray.yaml
+++ b/data/materials/overture/overture-asa-gray.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-asa-gray/f5a71c6399a2.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 70
+  max_bed_temperature: 95
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-asa-green.yaml
+++ b/data/materials/overture/overture-asa-green.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-asa-green/dc5f5f144c47.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 70
+  max_bed_temperature: 95
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-asa-natural.yaml
+++ b/data/materials/overture/overture-asa-natural.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-asa-natural/19459f6344e3.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 70
+  max_bed_temperature: 95
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-asa-olive-green.yaml
+++ b/data/materials/overture/overture-asa-olive-green.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-asa-olive-green/f15b6c5f9de2.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 70
+  max_bed_temperature: 95
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-asa-orange.yaml
+++ b/data/materials/overture/overture-asa-orange.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-asa-orange/51d902e1f517.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 70
+  max_bed_temperature: 95
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-asa-red.yaml
+++ b/data/materials/overture/overture-asa-red.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-asa-red/dd25cace3dd1.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 70
+  max_bed_temperature: 95
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-asa-white.yaml
+++ b/data/materials/overture/overture-asa-white.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-asa-white/d078929179c3.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 70
+  max_bed_temperature: 95
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-asa-yellow.yaml
+++ b/data/materials/overture/overture-asa-yellow.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-asa-yellow/e69629a52e29.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 240
+  max_print_temperature: 270
+  min_bed_temperature: 70
+  max_bed_temperature: 95
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-easy-nylon-black.yaml
+++ b/data/materials/overture/overture-easy-nylon-black.yaml
@@ -10,4 +10,10 @@ primary_color:
 photos:
   - url: https://files.openprinttag.org/overture/overture-easy-nylon-black/d1cab0e01959.jpg
     type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 260
+  min_bed_temperature: 50
+  max_bed_temperature: 50
+  drying_temperature: 95
+  drying_time: 420

--- a/data/materials/overture/overture-easy-nylon-grey.yaml
+++ b/data/materials/overture/overture-easy-nylon-grey.yaml
@@ -10,4 +10,10 @@ primary_color:
 photos:
   - url: https://files.openprinttag.org/overture/overture-easy-nylon-grey/2971aa07c875.jpg
     type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 245
+  max_print_temperature: 260
+  min_bed_temperature: 50
+  max_bed_temperature: 50
+  drying_temperature: 95
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-beige.yaml
+++ b/data/materials/overture/overture-easy-pla-beige.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#f7f6edff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-black.yaml
+++ b/data/materials/overture/overture-easy-pla-black.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-black/f0d8daba90f6.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-caramel.yaml
+++ b/data/materials/overture/overture-easy-pla-caramel.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-caramel/b110dda9f349.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-cobalt-blue.yaml
+++ b/data/materials/overture/overture-easy-pla-cobalt-blue.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#274da0ff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-digital-blue.yaml
+++ b/data/materials/overture/overture-easy-pla-digital-blue.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-digital-blue/147c0dce48ef.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-glow-blue.yaml
+++ b/data/materials/overture/overture-easy-pla-glow-blue.yaml
@@ -15,4 +15,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-glow-blue/2df16125b87d.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-glow-orange.yaml
+++ b/data/materials/overture/overture-easy-pla-glow-orange.yaml
@@ -15,4 +15,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-glow-orange/60cca8d6de43.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-glow-red.yaml
+++ b/data/materials/overture/overture-easy-pla-glow-red.yaml
@@ -18,4 +18,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-glow-red/3c568c60018b.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-glow-yellow.yaml
+++ b/data/materials/overture/overture-easy-pla-glow-yellow.yaml
@@ -15,4 +15,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-glow-yellow/b535ee8ee6b6.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-green.yaml
+++ b/data/materials/overture/overture-easy-pla-green.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-green/b15d6db4f828.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-magenta.yaml
+++ b/data/materials/overture/overture-easy-pla-magenta.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#fd3db5ff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-natural.yaml
+++ b/data/materials/overture/overture-easy-pla-natural.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-natural/bcd3ef6ae1e2.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-orange.yaml
+++ b/data/materials/overture/overture-easy-pla-orange.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-orange/8c1e0e289686.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-pine-green.yaml
+++ b/data/materials/overture/overture-easy-pla-pine-green.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#00a5a8ff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-pink.yaml
+++ b/data/materials/overture/overture-easy-pla-pink.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#ffc0cbff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-pumpkin-orange.yaml
+++ b/data/materials/overture/overture-easy-pla-pumpkin-orange.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#ff8d5cff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-purple.yaml
+++ b/data/materials/overture/overture-easy-pla-purple.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#7b49a2ff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-red.yaml
+++ b/data/materials/overture/overture-easy-pla-red.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-red/1f08465512bd.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-rock-white.yaml
+++ b/data/materials/overture/overture-easy-pla-rock-white.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-rock-white/98118eed0a9c.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-shimmer-bronze.yaml
+++ b/data/materials/overture/overture-easy-pla-shimmer-bronze.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-shimmer-bronze/44850a750710.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-shimmer-dark-green.yaml
+++ b/data/materials/overture/overture-easy-pla-shimmer-dark-green.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-shimmer-dark-green/2530bbacf26d.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-shimmer-purple.yaml
+++ b/data/materials/overture/overture-easy-pla-shimmer-purple.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-shimmer-purple/4b8e398bd9e6.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-shimmer-silver-green.yaml
+++ b/data/materials/overture/overture-easy-pla-shimmer-silver-green.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-shimmer-silver-green/9d1ecdda7c16.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-sky-blue.yaml
+++ b/data/materials/overture/overture-easy-pla-sky-blue.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#3bc9edff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-space-gray.yaml
+++ b/data/materials/overture/overture-easy-pla-space-gray.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-space-gray/002852c8785c.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-white.yaml
+++ b/data/materials/overture/overture-easy-pla-white.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-easy-pla-white/5c815d115a1d.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-yellow.yaml
+++ b/data/materials/overture/overture-easy-pla-yellow.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#fcff66ff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-easy-pla-yolk-yellow.yaml
+++ b/data/materials/overture/overture-easy-pla-yolk-yellow.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#ffe357ff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-glow-pla-white-green-in-dark.yaml
+++ b/data/materials/overture/overture-glow-pla-white-green-in-dark.yaml
@@ -18,4 +18,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-glow-pla-white-green-in-dark/656674aff031.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-army-green.yaml
+++ b/data/materials/overture/overture-matte-pla-army-green.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-army-green/c1617f902293.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-baby-pink.yaml
+++ b/data/materials/overture/overture-matte-pla-baby-pink.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - matte
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-bamboo-green.yaml
+++ b/data/materials/overture/overture-matte-pla-bamboo-green.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - matte
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-beige.yaml
+++ b/data/materials/overture/overture-matte-pla-beige.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - matte
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-black-white.yaml
+++ b/data/materials/overture/overture-matte-pla-black-white.yaml
@@ -16,4 +16,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-black-white/7b1227abfbfb.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-black.yaml
+++ b/data/materials/overture/overture-matte-pla-black.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-black/ff5f2aaedfbd.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-blue-red.yaml
+++ b/data/materials/overture/overture-matte-pla-blue-red.yaml
@@ -16,4 +16,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-blue-red/04d199cb53e7.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-blue.yaml
+++ b/data/materials/overture/overture-matte-pla-blue.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-blue/06ba1cdcc822.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-brick-red.yaml
+++ b/data/materials/overture/overture-matte-pla-brick-red.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-brick-red/c408e0b9079c.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-butter-yellow.yaml
+++ b/data/materials/overture/overture-matte-pla-butter-yellow.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - matte
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-candy-rainbow.yaml
+++ b/data/materials/overture/overture-matte-pla-candy-rainbow.yaml
@@ -19,4 +19,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-candy-rainbow/3f3290c8c117.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-chocolate.yaml
+++ b/data/materials/overture/overture-matte-pla-chocolate.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-chocolate/d371c3c13f12.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-grass-green.yaml
+++ b/data/materials/overture/overture-matte-pla-grass-green.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-grass-green/6f6df0bba991.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-green.yaml
+++ b/data/materials/overture/overture-matte-pla-green.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-green/10957c0254fa.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-light-blue-yellow.yaml
+++ b/data/materials/overture/overture-matte-pla-light-blue-yellow.yaml
@@ -16,4 +16,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-light-blue-yellow/18e6f41f32bb.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-light-blue.yaml
+++ b/data/materials/overture/overture-matte-pla-light-blue.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-light-blue/47b4058c1a60.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-light-brown.yaml
+++ b/data/materials/overture/overture-matte-pla-light-brown.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-light-brown/8eba64910c44.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-light-gray.yaml
+++ b/data/materials/overture/overture-matte-pla-light-gray.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-light-gray/46e64c897a91.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-light-green.yaml
+++ b/data/materials/overture/overture-matte-pla-light-green.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-light-green/967860c2720b.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-lilac.yaml
+++ b/data/materials/overture/overture-matte-pla-lilac.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - matte
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-navy-blue.yaml
+++ b/data/materials/overture/overture-matte-pla-navy-blue.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-navy-blue/5223db5393b5.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-orange-red.yaml
+++ b/data/materials/overture/overture-matte-pla-orange-red.yaml
@@ -16,4 +16,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-orange-red/e27ab71707ff.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-orange.yaml
+++ b/data/materials/overture/overture-matte-pla-orange.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-orange/ce23e9bbbba3.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-pastel-red.yaml
+++ b/data/materials/overture/overture-matte-pla-pastel-red.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - matte
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-pink.yaml
+++ b/data/materials/overture/overture-matte-pla-pink.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-pink/1d0f77a6cf8d.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-purple.yaml
+++ b/data/materials/overture/overture-matte-pla-purple.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-purple/ccc0467c5fd9.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-rainbow.yaml
+++ b/data/materials/overture/overture-matte-pla-rainbow.yaml
@@ -18,4 +18,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-rainbow/21631d98453b.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-red.yaml
+++ b/data/materials/overture/overture-matte-pla-red.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-red/d34e65bb9ccd.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-skin.yaml
+++ b/data/materials/overture/overture-matte-pla-skin.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-skin/56dfa7a4781e.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-turquoise.yaml
+++ b/data/materials/overture/overture-matte-pla-turquoise.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - matte
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-white.yaml
+++ b/data/materials/overture/overture-matte-pla-white.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-white/95dd18719c28.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-wood.yaml
+++ b/data/materials/overture/overture-matte-pla-wood.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-wood/abc5050453d7.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-matte-pla-yellow.yaml
+++ b/data/materials/overture/overture-matte-pla-yellow.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-matte-pla-yellow/700fdd921ccc.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pc-professional-black.yaml
+++ b/data/materials/overture/overture-pc-professional-black.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pc-professional-black/c0fe4c344111.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 250
+  max_print_temperature: 270
+  min_bed_temperature: 90
+  max_bed_temperature: 105
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-pc-professional-blue.yaml
+++ b/data/materials/overture/overture-pc-professional-blue.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pc-professional-blue/48f856d4d500.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 250
+  max_print_temperature: 270
+  min_bed_temperature: 90
+  max_bed_temperature: 105
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-pc-professional-transparent.yaml
+++ b/data/materials/overture/overture-pc-professional-transparent.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pc-professional-transparent/f58257e99c2b.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 250
+  max_print_temperature: 270
+  min_bed_temperature: 90
+  max_bed_temperature: 105
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-pc-professional-white.yaml
+++ b/data/materials/overture/overture-pc-professional-white.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pc-professional-white/86788b76c3ae.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 250
+  max_print_temperature: 270
+  min_bed_temperature: 90
+  max_bed_temperature: 105
+  drying_temperature: 75
+  drying_time: 420

--- a/data/materials/overture/overture-petg-army-green.yaml
+++ b/data/materials/overture/overture-petg-army-green.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-army-green/cdaa497bf461.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-black.yaml
+++ b/data/materials/overture/overture-petg-black.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-black/b71e3ffa8e74.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-blue.yaml
+++ b/data/materials/overture/overture-petg-blue.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-blue/f0f54d52b39b.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-brown.yaml
+++ b/data/materials/overture/overture-petg-brown.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-brown/66b95a1f7222.png
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-digital-blue.yaml
+++ b/data/materials/overture/overture-petg-digital-blue.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-digital-blue/113b4bba78fb.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-gold.yaml
+++ b/data/materials/overture/overture-petg-gold.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-gold/1a567148ca51.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-grass-green.yaml
+++ b/data/materials/overture/overture-petg-grass-green.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-grass-green/e22affb86379.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-green.yaml
+++ b/data/materials/overture/overture-petg-green.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-green/cb91b166aaa1.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-light-gray.yaml
+++ b/data/materials/overture/overture-petg-light-gray.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-light-gray/6ed9cd0f95a8.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-magenta.yaml
+++ b/data/materials/overture/overture-petg-magenta.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-magenta/d7d20f375ef4.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-orange.yaml
+++ b/data/materials/overture/overture-petg-orange.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-orange/b096dc07e4ed.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-pink.yaml
+++ b/data/materials/overture/overture-petg-pink.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-pink/dd78f008eadd.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-purple.yaml
+++ b/data/materials/overture/overture-petg-purple.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-purple/a74f74c5a4a2.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-red.yaml
+++ b/data/materials/overture/overture-petg-red.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-red/805c37dc503d.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-space-gray.yaml
+++ b/data/materials/overture/overture-petg-space-gray.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-space-gray/fcf88c2c68dd.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-sparkle-blue.yaml
+++ b/data/materials/overture/overture-petg-sparkle-blue.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-sparkle-blue/3eb0e85f498b.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-starry-blue.yaml
+++ b/data/materials/overture/overture-petg-starry-blue.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-starry-blue/88c90ea5c827.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-transparent-blue.yaml
+++ b/data/materials/overture/overture-petg-transparent-blue.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-transparent-blue/cb0a1201807b.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-transparent-green.yaml
+++ b/data/materials/overture/overture-petg-transparent-green.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-transparent-green/f59106cc846e.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-transparent-red.yaml
+++ b/data/materials/overture/overture-petg-transparent-red.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-transparent-red/450b07344db4.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-transparent.yaml
+++ b/data/materials/overture/overture-petg-transparent.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-transparent/01230b8f79b3.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-white.yaml
+++ b/data/materials/overture/overture-petg-white.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-white/0760173c135f.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-petg-yellow.yaml
+++ b/data/materials/overture/overture-petg-yellow.yaml
@@ -11,4 +11,10 @@ primary_color:
 photos:
 - url: https://files.openprinttag.org/overture/overture-petg-yellow/15993133c047.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-pla-aurora-berry.yaml
+++ b/data/materials/overture/overture-pla-aurora-berry.yaml
@@ -13,4 +13,10 @@ secondary_colors:
 tags:
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-avocado.yaml
+++ b/data/materials/overture/overture-pla-avocado.yaml
@@ -12,4 +12,10 @@ secondary_colors:
 tags:
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-black.yaml
+++ b/data/materials/overture/overture-pla-black.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-blue.yaml
+++ b/data/materials/overture/overture-pla-blue.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-brown.yaml
+++ b/data/materials/overture/overture-pla-brown.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-carbon-fiber-midnight-black.yaml
+++ b/data/materials/overture/overture-pla-carbon-fiber-midnight-black.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
   - url: https://files.openprinttag.org/overture/overture-pla-carbon-fiber-midnight-black/7f7d24b81b58.jpg
     type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-cement-gray.yaml
+++ b/data/materials/overture/overture-pla-cement-gray.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-champagne-frost.yaml
+++ b/data/materials/overture/overture-pla-champagne-frost.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#eccea7ff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-chocolate.yaml
+++ b/data/materials/overture/overture-pla-chocolate.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-christmas-prism.yaml
+++ b/data/materials/overture/overture-pla-christmas-prism.yaml
@@ -15,4 +15,10 @@ secondary_colors:
 tags:
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-cold-white.yaml
+++ b/data/materials/overture/overture-pla-cold-white.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#eaecf5ff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-fresh-red.yaml
+++ b/data/materials/overture/overture-pla-fresh-red.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-glow-white-green-in-dark.yaml
+++ b/data/materials/overture/overture-pla-glow-white-green-in-dark.yaml
@@ -16,4 +16,10 @@ tags:
 - illuminescent_color_change
 - abrasive
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-gray-blue.yaml
+++ b/data/materials/overture/overture-pla-gray-blue.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-green.yaml
+++ b/data/materials/overture/overture-pla-green.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-highlight-yellow.yaml
+++ b/data/materials/overture/overture-pla-highlight-yellow.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-lemon-yellow.yaml
+++ b/data/materials/overture/overture-pla-lemon-yellow.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#fbf942ff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-light-blue.yaml
+++ b/data/materials/overture/overture-pla-light-blue.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-light-gray.yaml
+++ b/data/materials/overture/overture-pla-light-gray.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-metallic-gray.yaml
+++ b/data/materials/overture/overture-pla-metallic-gray.yaml
@@ -10,4 +10,10 @@ secondary_colors:
 - color_rgba: '#7d8eaaff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-northern-lights.yaml
+++ b/data/materials/overture/overture-pla-northern-lights.yaml
@@ -14,4 +14,10 @@ secondary_colors:
 tags:
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-olive-green.yaml
+++ b/data/materials/overture/overture-pla-olive-green.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-orange.yaml
+++ b/data/materials/overture/overture-pla-orange.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-pink.yaml
+++ b/data/materials/overture/overture-pla-pink.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-army-green.yaml
+++ b/data/materials/overture/overture-pla-professional-army-green.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-army-green/1ecc0dc6d840.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-black.yaml
+++ b/data/materials/overture/overture-pla-professional-black.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-black/1de185212963.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-bronze.yaml
+++ b/data/materials/overture/overture-pla-professional-bronze.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#693721ff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-brown.yaml
+++ b/data/materials/overture/overture-pla-professional-brown.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-brown/e1bdb5007740.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-champagne.yaml
+++ b/data/materials/overture/overture-pla-professional-champagne.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#c0c4bbff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-chocolate.yaml
+++ b/data/materials/overture/overture-pla-professional-chocolate.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-chocolate/38425a329e42.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-copper.yaml
+++ b/data/materials/overture/overture-pla-professional-copper.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#c9774bff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-dark-blue.yaml
+++ b/data/materials/overture/overture-pla-professional-dark-blue.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-dark-blue/d6dc830e175d.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-digital-blue.yaml
+++ b/data/materials/overture/overture-pla-professional-digital-blue.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-digital-blue/9419981b62b6.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-fresh-red.yaml
+++ b/data/materials/overture/overture-pla-professional-fresh-red.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-fresh-red/efdfd0344acb.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-gray-blue.yaml
+++ b/data/materials/overture/overture-pla-professional-gray-blue.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-gray-blue/769b217855cf.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-green.yaml
+++ b/data/materials/overture/overture-pla-professional-green.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-green/e0e76eb85fb6.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-highlight-yellow.yaml
+++ b/data/materials/overture/overture-pla-professional-highlight-yellow.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-highlight-yellow/90e349e98206.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-light-blue.yaml
+++ b/data/materials/overture/overture-pla-professional-light-blue.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-light-gray.yaml
+++ b/data/materials/overture/overture-pla-professional-light-gray.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-light-gray/879933fff0d6.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-light-green.yaml
+++ b/data/materials/overture/overture-pla-professional-light-green.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-light-green/42736776f6ba.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-moonlight-silver.yaml
+++ b/data/materials/overture/overture-pla-professional-moonlight-silver.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#abacb0ff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-olive-green.yaml
+++ b/data/materials/overture/overture-pla-professional-olive-green.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-olive-green/ad1b97957004.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-orange.yaml
+++ b/data/materials/overture/overture-pla-professional-orange.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-orange/213def8d84d7.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-pink.yaml
+++ b/data/materials/overture/overture-pla-professional-pink.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-pink/26403a29beea.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-purple.yaml
+++ b/data/materials/overture/overture-pla-professional-purple.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-purple/6873a4d5e188.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-red.yaml
+++ b/data/materials/overture/overture-pla-professional-red.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-red/517340c658d4.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-royal-gold.yaml
+++ b/data/materials/overture/overture-pla-professional-royal-gold.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-royal-gold/6fb59b95963a.png
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-silver-metal.yaml
+++ b/data/materials/overture/overture-pla-professional-silver-metal.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-silver-metal/c28ef524fdb4.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-space-gray.yaml
+++ b/data/materials/overture/overture-pla-professional-space-gray.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-space-gray/6708079d83b4.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-sunset-rainbow.yaml
+++ b/data/materials/overture/overture-pla-professional-sunset-rainbow.yaml
@@ -17,4 +17,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-sunset-rainbow/239b31c87c9a.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-white.yaml
+++ b/data/materials/overture/overture-pla-professional-white.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-white/8a690541a6a7.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-wine.yaml
+++ b/data/materials/overture/overture-pla-professional-wine.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-wine/6d2121c2306f.png
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-professional-yellow.yaml
+++ b/data/materials/overture/overture-pla-professional-yellow.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-pla-professional-yellow/0aa6424b1c75.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-purple.yaml
+++ b/data/materials/overture/overture-pla-purple.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-rainbow.yaml
+++ b/data/materials/overture/overture-pla-rainbow.yaml
@@ -15,4 +15,10 @@ tags:
 - industrially_compostable
 - gradual_color_change
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-red.yaml
+++ b/data/materials/overture/overture-pla-red.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-rocket-pop.yaml
+++ b/data/materials/overture/overture-pla-rocket-pop.yaml
@@ -14,4 +14,10 @@ secondary_colors:
 tags:
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-royal-gold.yaml
+++ b/data/materials/overture/overture-pla-royal-gold.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-space-gray.yaml
+++ b/data/materials/overture/overture-pla-space-gray.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-sparkle-black.yaml
+++ b/data/materials/overture/overture-pla-sparkle-black.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - glitter
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-sparkle-purple.yaml
+++ b/data/materials/overture/overture-pla-sparkle-purple.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - glitter
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-tequila-sunrise.yaml
+++ b/data/materials/overture/overture-pla-tequila-sunrise.yaml
@@ -12,4 +12,10 @@ secondary_colors:
 tags:
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-white.yaml
+++ b/data/materials/overture/overture-pla-white.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-pla-yellow.yaml
+++ b/data/materials/overture/overture-pla-yellow.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - industrially_compostable
 photos: []
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 220
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-petg-white.yaml
+++ b/data/materials/overture/overture-rock-petg-white.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#edf0f2ff'
 tags:
 - imitates_marble
-properties: {}
+properties:
+  min_print_temperature: 230
+  max_print_temperature: 260
+  min_bed_temperature: 65
+  max_bed_temperature: 70
+  drying_temperature: 60
+  drying_time: 300

--- a/data/materials/overture/overture-rock-pla-alpine-forest.yaml
+++ b/data/materials/overture/overture-rock-pla-alpine-forest.yaml
@@ -13,4 +13,10 @@ secondary_colors:
 tags:
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-barrier-reef.yaml
+++ b/data/materials/overture/overture-rock-pla-barrier-reef.yaml
@@ -13,4 +13,10 @@ secondary_colors:
 tags:
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-cheesewood.yaml
+++ b/data/materials/overture/overture-rock-pla-cheesewood.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#da995fff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-desert-bluff.yaml
+++ b/data/materials/overture/overture-rock-pla-desert-bluff.yaml
@@ -12,4 +12,10 @@ secondary_colors:
 tags:
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-fossil-rock.yaml
+++ b/data/materials/overture/overture-rock-pla-fossil-rock.yaml
@@ -15,4 +15,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-rock-pla-fossil-rock/f99c9bc2caf6.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-glacier-blue.yaml
+++ b/data/materials/overture/overture-rock-pla-glacier-blue.yaml
@@ -15,4 +15,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-rock-pla-glacier-blue/0201557d7632.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-haze-gray.yaml
+++ b/data/materials/overture/overture-rock-pla-haze-gray.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - imitates_marble
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-jarrah.yaml
+++ b/data/materials/overture/overture-rock-pla-jarrah.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#c36561ff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-marigold-yellow.yaml
+++ b/data/materials/overture/overture-rock-pla-marigold-yellow.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - imitates_marble
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-mars-red.yaml
+++ b/data/materials/overture/overture-rock-pla-mars-red.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-rock-pla-mars-red/e717afc167b9.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-mist-gray.yaml
+++ b/data/materials/overture/overture-rock-pla-mist-gray.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - imitates_stone
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-moonlight-gray.yaml
+++ b/data/materials/overture/overture-rock-pla-moonlight-gray.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - imitates_stone
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-muted-gray.yaml
+++ b/data/materials/overture/overture-rock-pla-muted-gray.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - imitates_stone
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-painted-hills.yaml
+++ b/data/materials/overture/overture-rock-pla-painted-hills.yaml
@@ -14,4 +14,10 @@ secondary_colors:
 tags:
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-pink-lake.yaml
+++ b/data/materials/overture/overture-rock-pla-pink-lake.yaml
@@ -12,4 +12,10 @@ secondary_colors:
 tags:
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-rock-rainbow.yaml
+++ b/data/materials/overture/overture-rock-pla-rock-rainbow.yaml
@@ -17,4 +17,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-rock-pla-rock-rainbow/63f281e7a10c.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-rock-white.yaml
+++ b/data/materials/overture/overture-rock-pla-rock-white.yaml
@@ -15,4 +15,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-rock-pla-rock-white/84004b48699d.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-sedimentary-rock.yaml
+++ b/data/materials/overture/overture-rock-pla-sedimentary-rock.yaml
@@ -16,4 +16,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-rock-pla-sedimentary-rock/b6ec8e68cebf.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-sedona-red.yaml
+++ b/data/materials/overture/overture-rock-pla-sedona-red.yaml
@@ -13,4 +13,10 @@ secondary_colors:
 tags:
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-slate-gray.yaml
+++ b/data/materials/overture/overture-rock-pla-slate-gray.yaml
@@ -11,4 +11,10 @@ primary_color:
 tags:
 - imitates_marble
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-tropical-jungle.yaml
+++ b/data/materials/overture/overture-rock-pla-tropical-jungle.yaml
@@ -13,4 +13,10 @@ secondary_colors:
 tags:
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-walnut-wood.yaml
+++ b/data/materials/overture/overture-rock-pla-walnut-wood.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#976b62ff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-wetland-green.yaml
+++ b/data/materials/overture/overture-rock-pla-wetland-green.yaml
@@ -12,4 +12,10 @@ secondary_colors:
 tags:
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-rock-pla-white-oak.yaml
+++ b/data/materials/overture/overture-rock-pla-white-oak.yaml
@@ -10,4 +10,10 @@ primary_color:
   color_rgba: '#d4b6a3ff'
 tags:
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 50
+  max_bed_temperature: 70
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-blue.yaml
+++ b/data/materials/overture/overture-silk-pla-blue.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-blue/bc6b6719437f.png
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-caramel.yaml
+++ b/data/materials/overture/overture-silk-pla-caramel.yaml
@@ -14,4 +14,10 @@ tags:
 - gradual_color_change
 - silk
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-christmas-red.yaml
+++ b/data/materials/overture/overture-silk-pla-christmas-red.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-christmas-red/e6aa557bfe7d.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-chrome-gray.yaml
+++ b/data/materials/overture/overture-silk-pla-chrome-gray.yaml
@@ -13,4 +13,10 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-copper-shore.yaml
+++ b/data/materials/overture/overture-silk-pla-copper-shore.yaml
@@ -13,4 +13,10 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-copper.yaml
+++ b/data/materials/overture/overture-silk-pla-copper.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-copper/bb9413ae22a4.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-dual-colors-blue-silver.yaml
+++ b/data/materials/overture/overture-silk-pla-dual-colors-blue-silver.yaml
@@ -15,4 +15,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-dual-colors-blue-silver/30cf204f9279.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-dual-colors-blue-yellow.yaml
+++ b/data/materials/overture/overture-silk-pla-dual-colors-blue-yellow.yaml
@@ -16,4 +16,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-dual-colors-blue-yellow/80f37549dcc3.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-dual-colors-gold-silver.yaml
+++ b/data/materials/overture/overture-silk-pla-dual-colors-gold-silver.yaml
@@ -16,4 +16,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-dual-colors-gold-silver/58b469070007.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-dual-colors-green-blue.yaml
+++ b/data/materials/overture/overture-silk-pla-dual-colors-green-blue.yaml
@@ -16,4 +16,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-dual-colors-green-blue/86ebda68bba3.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-dual-colors-green-magenta.yaml
+++ b/data/materials/overture/overture-silk-pla-dual-colors-green-magenta.yaml
@@ -16,4 +16,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-dual-colors-green-magenta/e65957c82e10.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-dual-colors-green-silver.yaml
+++ b/data/materials/overture/overture-silk-pla-dual-colors-green-silver.yaml
@@ -16,4 +16,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-dual-colors-green-silver/fa591cc05144.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-dual-colors-magenta-gold.yaml
+++ b/data/materials/overture/overture-silk-pla-dual-colors-magenta-gold.yaml
@@ -16,4 +16,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-dual-colors-magenta-gold/c02cb256b2ed.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-dual-colors-purple-gold.yaml
+++ b/data/materials/overture/overture-silk-pla-dual-colors-purple-gold.yaml
@@ -16,4 +16,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-dual-colors-purple-gold/86c770c9dd66.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-dual-colors-red-gold.yaml
+++ b/data/materials/overture/overture-silk-pla-dual-colors-red-gold.yaml
@@ -16,4 +16,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-dual-colors-red-gold/b81a8a15b8f2.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-evergreen-bronze.yaml
+++ b/data/materials/overture/overture-silk-pla-evergreen-bronze.yaml
@@ -13,4 +13,10 @@ tags:
 - gradual_color_change
 - silk
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-fresh-red.yaml
+++ b/data/materials/overture/overture-silk-pla-fresh-red.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-fresh-red/52b53062e010.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-glacier-flash.yaml
+++ b/data/materials/overture/overture-silk-pla-glacier-flash.yaml
@@ -14,4 +14,10 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-gold.yaml
+++ b/data/materials/overture/overture-silk-pla-gold.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-gold/6a9b359d792c.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-golden-ember.yaml
+++ b/data/materials/overture/overture-silk-pla-golden-ember.yaml
@@ -13,4 +13,10 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-gray.yaml
+++ b/data/materials/overture/overture-silk-pla-gray.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-gray/ba641fdf3631.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-green.yaml
+++ b/data/materials/overture/overture-silk-pla-green.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-green/126dba915603.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-lettuce-tomato.yaml
+++ b/data/materials/overture/overture-silk-pla-lettuce-tomato.yaml
@@ -13,4 +13,10 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-lime-surge.yaml
+++ b/data/materials/overture/overture-silk-pla-lime-surge.yaml
@@ -13,4 +13,10 @@ tags:
 - gradual_color_change
 - silk
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-neon-green.yaml
+++ b/data/materials/overture/overture-silk-pla-neon-green.yaml
@@ -15,4 +15,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-neon-green/a8afa330b07d.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-parakeet.yaml
+++ b/data/materials/overture/overture-silk-pla-parakeet.yaml
@@ -15,4 +15,10 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-periwinkle.yaml
+++ b/data/materials/overture/overture-silk-pla-periwinkle.yaml
@@ -14,4 +14,10 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-punch-pink.yaml
+++ b/data/materials/overture/overture-silk-pla-punch-pink.yaml
@@ -13,4 +13,10 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-purple-chrome.yaml
+++ b/data/materials/overture/overture-silk-pla-purple-chrome.yaml
@@ -14,4 +14,10 @@ tags:
 - gradual_color_change
 - silk
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-red.yaml
+++ b/data/materials/overture/overture-silk-pla-red.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-red/203a08384f61.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-silk-purple.yaml
+++ b/data/materials/overture/overture-silk-pla-silk-purple.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-silk-purple/ee75f54823ac.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-silver.yaml
+++ b/data/materials/overture/overture-silk-pla-silver.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-silver/959a920e5e34.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-tiger-eye.yaml
+++ b/data/materials/overture/overture-silk-pla-tiger-eye.yaml
@@ -14,4 +14,10 @@ tags:
 - gradual_color_change
 - silk
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-tropic.yaml
+++ b/data/materials/overture/overture-silk-pla-tropic.yaml
@@ -14,4 +14,10 @@ tags:
 - gradual_color_change
 - silk
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-vaporwave.yaml
+++ b/data/materials/overture/overture-silk-pla-vaporwave.yaml
@@ -13,4 +13,10 @@ tags:
 - silk
 - gradual_color_change
 - industrially_compostable
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-silk-pla-white.yaml
+++ b/data/materials/overture/overture-silk-pla-white.yaml
@@ -14,4 +14,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-silk-pla-white/7faaaf0ef08f.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 200
+  max_print_temperature: 220
+  min_bed_temperature: 50
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-super-pla-black.yaml
+++ b/data/materials/overture/overture-super-pla-black.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-super-pla-black/53061f028b24.png
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-super-pla-dark-blue.yaml
+++ b/data/materials/overture/overture-super-pla-dark-blue.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-super-pla-dark-blue/d9287484e4c5.png
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-super-pla-green.yaml
+++ b/data/materials/overture/overture-super-pla-green.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-super-pla-green/f5ef8c137619.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-super-pla-light-brown.yaml
+++ b/data/materials/overture/overture-super-pla-light-brown.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-super-pla-light-brown/37575fa40757.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-super-pla-light-gray.yaml
+++ b/data/materials/overture/overture-super-pla-light-gray.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-super-pla-light-gray/13973cb337e2.png
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-super-pla-orange.yaml
+++ b/data/materials/overture/overture-super-pla-orange.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-super-pla-orange/5aea0931dbd6.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-super-pla-pink.yaml
+++ b/data/materials/overture/overture-super-pla-pink.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-super-pla-pink/e27388d1b85c.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-super-pla-purple.yaml
+++ b/data/materials/overture/overture-super-pla-purple.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-super-pla-purple/922e640efc01.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-super-pla-red.yaml
+++ b/data/materials/overture/overture-super-pla-red.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-super-pla-red/daf500b67747.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-super-pla-sakura-pink.yaml
+++ b/data/materials/overture/overture-super-pla-sakura-pink.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-super-pla-sakura-pink/f6754b3c1677.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-super-pla-white.yaml
+++ b/data/materials/overture/overture-super-pla-white.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-super-pla-white/1735b002de8c.png
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-super-pla-yellow.yaml
+++ b/data/materials/overture/overture-super-pla-yellow.yaml
@@ -13,4 +13,10 @@ tags:
 photos:
 - url: https://files.openprinttag.org/overture/overture-super-pla-yellow/f223384b08ce.jpg
   type: unspecified
-properties: {}
+properties:
+  min_print_temperature: 190
+  max_print_temperature: 230
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 50
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-black.yaml
+++ b/data/materials/overture/overture-tpu-black.yaml
@@ -13,3 +13,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-blue.yaml
+++ b/data/materials/overture/overture-tpu-blue.yaml
@@ -13,3 +13,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-bright-pink.yaml
+++ b/data/materials/overture/overture-tpu-bright-pink.yaml
@@ -13,3 +13,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-brown.yaml
+++ b/data/materials/overture/overture-tpu-brown.yaml
@@ -13,3 +13,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-digital-blue.yaml
+++ b/data/materials/overture/overture-tpu-digital-blue.yaml
@@ -13,3 +13,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-gray.yaml
+++ b/data/materials/overture/overture-tpu-gray.yaml
@@ -13,3 +13,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-green.yaml
+++ b/data/materials/overture/overture-tpu-green.yaml
@@ -13,3 +13,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-black.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-black.yaml
@@ -15,3 +15,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-clear.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-clear.yaml
@@ -16,3 +16,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-grass-green.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-grass-green.yaml
@@ -15,3 +15,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-gray.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-gray.yaml
@@ -15,3 +15,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-luminous-blue.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-luminous-blue.yaml
@@ -17,3 +17,9 @@ tags:
 - abrasive
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-luminous-electric-indigo.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-luminous-electric-indigo.yaml
@@ -17,3 +17,9 @@ tags:
 - abrasive
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-luminous-green.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-luminous-green.yaml
@@ -17,3 +17,9 @@ tags:
 - abrasive
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-luminous-orange.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-luminous-orange.yaml
@@ -17,3 +17,9 @@ tags:
 - abrasive
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-luminous-pink.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-luminous-pink.yaml
@@ -15,3 +15,9 @@ tags:
 - high_speed
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-neon-magenta.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-neon-magenta.yaml
@@ -13,3 +13,9 @@ tags:
 - high_speed
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-neon-yellow.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-neon-yellow.yaml
@@ -13,3 +13,9 @@ tags:
 - high_speed
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-orange.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-orange.yaml
@@ -15,3 +15,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-pastel-rose.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-pastel-rose.yaml
@@ -12,3 +12,9 @@ tags:
 - high_speed
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-pink.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-pink.yaml
@@ -15,3 +15,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-translucent-blue.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-translucent-blue.yaml
@@ -16,3 +16,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-translucent-green.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-translucent-green.yaml
@@ -13,3 +13,9 @@ tags:
 - high_speed
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-translucent-orange.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-translucent-orange.yaml
@@ -13,3 +13,9 @@ tags:
 - high_speed
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-translucent-purple.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-translucent-purple.yaml
@@ -13,3 +13,9 @@ tags:
 - high_speed
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-translucent-red.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-translucent-red.yaml
@@ -16,3 +16,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-high-speed-white.yaml
+++ b/data/materials/overture/overture-tpu-high-speed-white.yaml
@@ -15,3 +15,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 200
+  max_print_temperature: 240
+  min_bed_temperature: 25
+  max_bed_temperature: 60
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-light-green.yaml
+++ b/data/materials/overture/overture-tpu-light-green.yaml
@@ -10,3 +10,9 @@ primary_color:
   color_rgba: '#70fa00ff'
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-neon-green.yaml
+++ b/data/materials/overture/overture-tpu-neon-green.yaml
@@ -12,3 +12,9 @@ tags:
 - neon
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-neon-orange.yaml
+++ b/data/materials/overture/overture-tpu-neon-orange.yaml
@@ -12,3 +12,9 @@ tags:
 - neon
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-neon-red.yaml
+++ b/data/materials/overture/overture-tpu-neon-red.yaml
@@ -12,3 +12,9 @@ tags:
 - neon
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-orange.yaml
+++ b/data/materials/overture/overture-tpu-orange.yaml
@@ -13,3 +13,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-purple.yaml
+++ b/data/materials/overture/overture-tpu-purple.yaml
@@ -13,3 +13,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-red.yaml
+++ b/data/materials/overture/overture-tpu-red.yaml
@@ -13,3 +13,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-space-grey.yaml
+++ b/data/materials/overture/overture-tpu-space-grey.yaml
@@ -13,3 +13,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-transparent.yaml
+++ b/data/materials/overture/overture-tpu-transparent.yaml
@@ -15,3 +15,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-white.yaml
+++ b/data/materials/overture/overture-tpu-white.yaml
@@ -13,3 +13,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420

--- a/data/materials/overture/overture-tpu-yellow.yaml
+++ b/data/materials/overture/overture-tpu-yellow.yaml
@@ -13,3 +13,9 @@ photos:
   type: unspecified
 properties:
   hardness_shore_a: 95
+  min_print_temperature: 210
+  max_print_temperature: 240
+  min_bed_temperature: 35
+  max_bed_temperature: 50
+  drying_temperature: 70
+  drying_time: 420


### PR DESCRIPTION
## Summary
- add official Overture nozzle and bed temperature ranges
- add manufacturer drying temperatures and times
- preserve existing TPU Shore hardness values
- leave legacy families without current catalog mappings unchanged

## Validation
- `venv/bin/python scripts/validate_json_schema.py`
- validated 26,771 files with no errors